### PR TITLE
fix: manage error when a BasePredictor.setup is not coroutine

### DIFF
--- a/examples/predict.py
+++ b/examples/predict.py
@@ -13,8 +13,8 @@ class PredictResponse(BaseModel):
 class Predictor(BasePredictor):
     def predict(self, *args, **kwargs) -> PredictResponse:
         return PredictResponse(
-                image="https://example.com/image.jpg", text="Hello world"
+            image="https://example.com/image.jpg", text="Hello world"
         )
 
-    async def setup(self):
+    def setup(self):
         logging.info("I'm ready")

--- a/inferia/core/app.py
+++ b/inferia/core/app.py
@@ -15,12 +15,23 @@ from inferia.api.handlers import (
 )
 from inferia.api.responses import ErrorResponse
 from inferia.core.config import ConfigFile
-from inferia.core.exceptioin_handlers import (too_many_requests_exception_handler, validation_exception_handler)
-from inferia.core.exceptions import (ConfigFileNotFoundError, NoThreadsAvailableError, SetupError)
+from inferia.core.exceptioin_handlers import (
+    too_many_requests_exception_handler,
+    validation_exception_handler,
+)
+from inferia.core.exceptions import (
+    ConfigFileNotFoundError,
+    NoThreadsAvailableError,
+    SetupError,
+)
 from inferia.core.logging import get_logger
 from inferia.core.models import BasePredictor
-from inferia.core.utils import (create_routes_semaphores, get_predictor_handler_return_type, load_predictor,
-                                wrap_handler, )
+from inferia.core.utils import (
+    create_routes_semaphores,
+    get_predictor_handler_return_type,
+    load_predictor,
+    wrap_handler,
+)
 
 
 class Application:
@@ -28,21 +39,21 @@ class Application:
     ready: bool
 
     def __init__(
-            self,
-            config_file_path: str = ".",
-            logger: Union[Any, logging.Logger] = None,
+        self,
+        config_file_path: str = ".",
+        logger: Union[Any, logging.Logger] = None,
     ):
 
         self._logger = logger or Application._get_default_logger()
 
         try:
             self.config = ConfigFile.load_from_file(
-                    os.path.join(f"{config_file_path}/inferia.yaml")
+                os.path.join(f"{config_file_path}/inferia.yaml")
             )
         except ConfigFileNotFoundError as e:
             self._logger.warning(
-                    "config file does not exist. Using default configuration.",
-                    extra={"error": str(e), "config_file_path": config_file_path},
+                "config file does not exist. Using default configuration.",
+                extra={"error": str(e), "config_file_path": config_file_path},
             )
             self.config = ConfigFile.default()
 
@@ -61,18 +72,18 @@ class Application:
                 yield
             except SetupError as e:
                 self._logger.critical(
-                        "Unable to start application",
-                        extra={"error": e},
+                    "Unable to start application",
+                    extra={"error": e},
                 )
                 sys.exit(1)
 
         self.app = FastAPI(
-                title=self.config.inferia.server.name,
-                version=self.config.inferia.server.version,
-                description=self.config.inferia.server.description,
-                access_log=self.config.inferia.server.fastapi.access_log,
-                debug=self.config.inferia.server.fastapi.debug,
-                lifespan=lifespan,
+            title=self.config.inferia.server.name,
+            version=self.config.inferia.server.version,
+            description=self.config.inferia.server.description,
+            access_log=self.config.inferia.server.fastapi.access_log,
+            debug=self.config.inferia.server.fastapi.debug,
+            lifespan=lifespan,
         )
 
         # FastAPIInstrumentor.instrument_app(self.app, excluded_urls=",".join(
@@ -97,82 +108,98 @@ class Application:
             self.map_model_to_instance[route.predictor] = predictor
         else:
             self._logger.info(
-                    "Predictor class already loaded",
-                    extra={"predictor": route.predictor},
+                "Predictor class already loaded",
+                extra={"predictor": route.predictor},
             )
 
         model = self.map_model_to_instance.get(route.predictor)
         response_model = get_predictor_handler_return_type(model)
 
         handler = wrap_handler(
-                descriptor=route.predictor,
-                original_handler=getattr(
-                        self.map_model_to_instance.get(route.predictor), "predict"
-                ),
-                semaphore=semaphores[route.predictor],
-                response_model=response_model,
+            descriptor=route.predictor,
+            original_handler=getattr(
+                self.map_model_to_instance.get(route.predictor), "predict"
+            ),
+            semaphore=semaphores[route.predictor],
+            response_model=response_model,
         )
 
         self.app.add_api_route(
-                route.path,
-                handler,
-                methods=["POST"],
-                name=route.name,
-                description=route.description,
-                tags=route.tags,
-                response_model=response_model,
-                responses={500: {"model": ErrorResponse}},
+            route.path,
+            handler,
+            methods=["POST"],
+            name=route.name,
+            description=route.description,
+            tags=route.tags,
+            response_model=response_model,
+            responses={500: {"model": ErrorResponse}},
         )
 
         self.app.add_exception_handler(
-                RequestValidationError, validation_exception_handler
+            RequestValidationError, validation_exception_handler
         )
         self.app.add_exception_handler(
-                NoThreadsAvailableError, too_many_requests_exception_handler
+            NoThreadsAvailableError, too_many_requests_exception_handler
         )
 
     def _set_default_routes(self) -> None:
         """Include default routes"""
         self.app.add_api_route(
-                "/health-check",
-                health_check_handler,
-                methods=["GET"],
-                name="health_check",
-                description="Health check endpoint",
-                tags=["health"],
+            "/health-check",
+            health_check_handler,
+            methods=["GET"],
+            name="health_check",
+            description="Health check endpoint",
+            tags=["health"],
         )
 
         self.app.add_api_route(
-                "/metrics",
-                metrics_handler,
-                methods=["GET"],
-                name="metrics",
-                description="Metrics endpoint",
-                tags=["metrics"],
+            "/metrics",
+            metrics_handler,
+            methods=["GET"],
+            name="metrics",
+            description="Metrics endpoint",
+            tags=["metrics"],
         )
 
     async def setup(self, app: FastAPI):
         self._logger.info("Setting up application", extra={})
         for predictor in self.map_model_to_instance.values():
+
+            # check if the predictor has a setup method
+            if not hasattr(predictor, "setup"):
+                self._logger.warning(
+                    "Predictor does not have a setup method",
+                    extra={"predictor": predictor.__class__.__name__},
+                )
+                continue
+
+            # check if method is a coroutine
+            if not asyncio.iscoroutinefunction(predictor.setup):
+                self._logger.warning(
+                    "Predictor setup method is not a coroutine",
+                    extra={"predictor": predictor.__class__.__name__},
+                )
+                continue
             try:
                 self._logger.debug(
-                        "Setting up predictor",
-                        extra={"predictor": predictor.__class__.__name__},
+                    "Setting up predictor",
+                    extra={"predictor": predictor.__class__.__name__},
                 )
                 await predictor.setup()
             except Exception as e:
                 self._logger.critical(
-                        "Unable to setting up predictor",
-                        extra={"predictor": predictor.__class__.__name__, "error": e},
+                    "Unable to setting up predictor",
+                    extra={"predictor": predictor.__class__.__name__, "error": e},
                 )
                 raise SetupError(predictor.__class__.__name__, e)
         app.state.ready = True
 
     def run(self):
         uvicorn.run(
-                self.app,
-                host=self.config.inferia.server.fastapi.host,
-                port=self.config.inferia.server.fastapi.port,
+            self.app,
+            host=self.config.inferia.server.fastapi.host,
+            port=self.config.inferia.server.fastapi.port,
         )
 
     @classmethod


### PR DESCRIPTION
This pull request includes changes to improve the setup process and enhance code readability in the `examples/predict.py` and `inferia/core/app.py` files. The most important changes include modifying the `setup` method to be synchronous, restructuring import statements for better readability, and adding checks for the `setup` method in predictors.

Changes to the setup process:

* [`examples/predict.py`](diffhunk://#diff-0aae350a4ae0b1b8dc4af9607c5a85f5941091eae5f3939363a70768089ec64fL19-R19): Changed the `setup` method from asynchronous to synchronous.

Code readability improvements:

* [`inferia/core/app.py`](diffhunk://#diff-c3817785377e2e279521faab493127188a8c6ac3707c3ce6458d065782641facL18-R34): Restructured import statements to follow a more readable format.

Enhancements to predictor setup:

* [`inferia/core/app.py`](diffhunk://#diff-c3817785377e2e279521faab493127188a8c6ac3707c3ce6458d065782641facR168-R183): Added checks to ensure that predictors have a `setup` method and that it is a coroutine.