### PR TITLE
refactor(config): remove hard-coded IP address and allow server to li…

### DIFF
--- a/cogito/core/config.py
+++ b/cogito/core/config.py
@@ -53,7 +53,7 @@ class RouteConfig(BaseModel):
 
 
 class FastAPIConfig(BaseModel):
-    host: str = "127.0.0.1"
+    host: str = "0.0.0.0"
     port: int = 8000
     debug: bool = False
     access_log: bool = True


### PR DESCRIPTION
…sten on any available IP

- Replace "127.0.0.1" with "0.0.0.0". This is a required configuration to let API respond inside containers or when working in a K8S cluster.


This pull request includes a change to the `cogito/core/config.py` file to update the default host configuration for the `FastAPIConfig` class. The most important change is:

* [`cogito/core/config.py`](diffhunk://#diff-456946048e87e80631bfef8a4d5a819d6591d2cc1707f85b0fa7c40edaef2c8aL56-R56): Modified the `host` attribute in the `FastAPIConfig` class from "127.0.0.1" to "0.0.0.0".