### PR TITLE
refactor(initialize,config): Update project initialization and configuration defaults

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -22,7 +22,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[dev]
+          pip install -e ".[dev]"
+          pip install pytest
 
       - name: Run tests using Makefile target
         run: python -m pytest

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -1,0 +1,23 @@
+name: "Pull Request Tests"
+
+on:
+  pull_request:
+    # Run this workflow on pull requests for all branches.
+    branches: ["*"]
+
+jobs:
+  test:
+    name: Run Python Tests on PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Run tests using Makefile target
+        run:  python -m pytest

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -19,5 +19,10 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+
       - name: Run tests using Makefile target
-        run:  python -m pytest
+        run: python -m pytest

--- a/cogito/core/config.py
+++ b/cogito/core/config.py
@@ -69,12 +69,12 @@ class ServerConfig(BaseModel):
     """
 
     name: str
-    description: Optional[str] = None
+    description: Optional[str]
     version: Optional[str] = "1.0.0"
     fastapi: FastAPIConfig
-    route: RouteConfig
+    route: Optional[RouteConfig]
     cache_dir: str = None
-    threads: int
+    threads: Optional[int] = 1
 
     @classmethod
     def default(cls):
@@ -135,9 +135,11 @@ class ConfigFile(BaseModel):
             with open(file_path, "r") as file:
                 yaml_data = yaml.safe_load(file)
             return cls(**yaml_data)
-        except FileNotFoundError:
+        except FileNotFoundError as e:
+            print(e)
             raise ConfigFileNotFoundError(file_path)
-        except Exception:
+        except Exception as e:
+            print(e)
             raise ValueError(f"Error loading configuration file {file_path}")
 
     def save_to_file(self, file_path: str) -> None:

--- a/cogito/core/config.py
+++ b/cogito/core/config.py
@@ -135,11 +135,9 @@ class ConfigFile(BaseModel):
             with open(file_path, "r") as file:
                 yaml_data = yaml.safe_load(file)
             return cls(**yaml_data)
-        except FileNotFoundError as e:
-            print(e)
+        except FileNotFoundError:
             raise ConfigFileNotFoundError(file_path)
-        except Exception as e:
-            print(e)
+        except Exception:
             raise ValueError(f"Error loading configuration file {file_path}")
 
     def save_to_file(self, file_path: str) -> None:

--- a/tests/commands/test_initialize.py
+++ b/tests/commands/test_initialize.py
@@ -1,0 +1,89 @@
+import os
+import pytest
+from click.testing import CliRunner
+from unittest.mock import patch
+
+from cogito.commands.initialize import init
+from cogito.core.config import ConfigFile
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def clean_config():
+    # Remove config file if exists before each test
+    if os.path.exists("cogito.yaml"):
+        os.remove("cogito.yaml")
+    yield
+    # Cleanup after test3
+    if os.path.exists("cogito.yaml"):
+        os.remove("cogito.yaml")
+
+
+def test_init_default(runner, clean_config):
+    result = runner.invoke(init, ["--default"])
+    assert result.exit_code == 0
+    assert "Initializing..." in result.output
+    assert os.path.exists("cogito.yaml")
+    
+    # Verify config file was created with default values
+    config = ConfigFile.load_from_file("cogito.yaml")
+    assert config.cogito.server.name == "Cogito ergo sum"
+    assert config.cogito.server.version == "0.1.0"
+    assert config.cogito.server.fastapi.host == "0.0.0.0"
+    assert config.cogito.server.fastapi.port == 8000
+
+
+def test_init_prompted(runner, clean_config):
+    # Mock user input values
+    inputs = [
+        "Test Project",  # name
+        "Test Description",  # description 
+        "0.1.0",  # version
+        "localhost",  # host
+        "8080",  # port
+        "n",  # debug mode
+        "n",  # access log
+        "y",  # add default route
+        "/tmp/cache",  # cache dir
+    ]
+    
+    result = runner.invoke(init, input="\n".join(inputs))
+    assert result.exit_code == 0
+    assert "Initializing..." in result.output
+    assert os.path.exists("cogito.yaml")
+    
+    # Verify config file was created with prompted values
+    config = ConfigFile.load_from_file("cogito.yaml")
+    assert config.cogito.server.name == "Test Project"
+    assert config.cogito.server.description == "Test Description"
+    assert config.cogito.server.version == "0.1.0"
+    assert config.cogito.server.fastapi.host == "localhost"
+    assert config.cogito.server.fastapi.port == 8080
+    assert config.cogito.server.fastapi.debug is False
+    assert config.cogito.server.fastapi.access_log is False
+    assert config.cogito.server.cache_dir == "/tmp/cache"
+
+
+def test_init_already_exists(runner, clean_config):
+    # Create initial config
+    runner.invoke(init, ["--default"])
+    
+    # Try to initialize again
+    result = runner.invoke(init)
+    assert result.exit_code == 0
+    assert "Already initialized." in result.output
+
+
+def test_init_force(runner, clean_config):
+    # Create initial config
+    runner.invoke(init, ["--default"])
+    
+    # Force new initialization
+    result = runner.invoke(init, ["--force", "--default"])
+    assert result.exit_code == 0
+    assert "Already initialized." not in result.output
+    assert "Initializing..." in result.output


### PR DESCRIPTION
**Title:** Refactor Initialization & Add PR Test Workflow

**Description:**

This PR introduces the following key updates:

- **GitHub Actions Workflow**:  
  - Adds `.github/workflows/pr-tests.yaml` to automatically run tests on every pull request.
  - Sets up Python 3.10, checks out the repo, and runs tests using `python -m pytest`.

- **Initialization Command Enhancements**:  
  - Updates the default project name from "Sapientia per Inferentiam" to "Cogito ergo sum".
  - Simplifies route configuration by using a single default `route` instead of a list.
  - Improves handling of the CLI context by safely retrieving `config_path`.

- **Configuration Model Improvements**:  
  - In `ServerConfig`, the `description` is now optional, `route` is declared as `Optional[RouteConfig]`, and `threads` defaults to `1`.
  - Enhances error reporting when loading the configuration file.

- **Additional Tests**:  
  - Adds tests in `tests/commands/test_initialize.py` to validate default, prompted, and forced initialization, along with handling already existing configurations.

These changes improve automation, usability, and reliability of the project setup.