### PR TITLE
refactor(config,template): Simplify route configuration and update predict template

### DIFF
--- a/cogito/core/config.py
+++ b/cogito/core/config.py
@@ -6,18 +6,6 @@ from pydantic import BaseModel
 
 from cogito.core.exceptions import ConfigFileNotFoundError
 
-
-class ArgConfig(BaseModel):
-    name: str
-    type: str
-    description: Optional[str] = None
-
-
-class ResponseConfig(BaseModel):
-    type: str
-    description: Optional[str] = None
-
-
 class RouteConfig(BaseModel):
     """
     Route configuration.
@@ -27,8 +15,6 @@ class RouteConfig(BaseModel):
     description: Optional[str] = None
     path: str
     predictor: str
-    args: Optional[List["ArgConfig"]] = None
-    response: Optional["ResponseConfig"] = None
     tags: List[str] = List
 
     @classmethod
@@ -38,16 +24,6 @@ class RouteConfig(BaseModel):
                 description="Make a single prediction",
                 path="/v1/predict",
                 predictor="predict:Predictor",
-                args=[
-                    ArgConfig(
-                            name="prompt",
-                            type="str",
-                            description="The prompt to generate text from",
-                    )
-                ],
-                response=ResponseConfig(
-                        type="PredictResponse", description="The generated text"
-                ),
                 tags=["predict"],
         )
 
@@ -56,7 +32,7 @@ class FastAPIConfig(BaseModel):
     host: str = "0.0.0.0"
     port: int = 8000
     debug: bool = False
-    access_log: bool = True
+    access_log: bool = False
 
     @classmethod
     def default(cls):
@@ -70,7 +46,7 @@ class ServerConfig(BaseModel):
 
     name: str
     description: Optional[str]
-    version: Optional[str] = "1.0.0"
+    version: Optional[str] = "0.1.0"
     fastapi: FastAPIConfig
     route: Optional[RouteConfig]
     cache_dir: str = None
@@ -84,7 +60,7 @@ class ServerConfig(BaseModel):
                 version="0.1.0",
                 fastapi=FastAPIConfig.default(),
                 route=RouteConfig.default(),
-                cache_dir="/tmp/cogito",
+                cache_dir="/tmp",
                 threads=1,
         )
 

--- a/cogito/templates/predict_class_template.jinja2
+++ b/cogito/templates/predict_class_template.jinja2
@@ -8,16 +8,6 @@ class {{ route.class_name }}(BasePredictor):
         {{ route.class_data.description | indent(8) }}
     Route path: {{ route.class_data.path }}
     Tags: {{ route.class_data.tags }}
-    {%- if route.class_data.args %}
-    Args:
-        {%- for arg in route.class_data.args %}
-        {{ arg.name }}: {{ arg.type }} - {{ arg.description }}
-        {%- endfor %}
-    {%- endif %}
-    {%- if route.class_data.response %}
-    Response:
-        {{ route.class_data.response.type }} - {{ route.class_data.response.description }}
-    {%- endif %}
     """
 
     async def setup(self):
@@ -29,23 +19,23 @@ class {{ route.class_name }}(BasePredictor):
 
         pass
 
-    {% if route.class_data.args %}
-    def predict(self, {% for arg in route.class_data.args %}{{ arg.name }}: {{ arg.type }}{% if not loop.last %}, {% endif %}{% endfor %}) -> {% if route.class_data.response %}{{ route.class_data.response.type }}{% else %}None{% endif %}:
-    {% else %}
-    def predict(self, *args, **kwargs) -> {% if route.class_data.response %}{{ route.class_data.response.type }}{% else %}None{% endif %}:
-    {%- endif %}
+    def predict(self, prompt: str, temperature: float, steps: int) -> string:
         """
-        This method is called for each prediction request.
+
+        # TODO: (USER) Implement the predict method for inference using your parameters
+        This method is called for each prediction request. 
+        
+        Parameters:
+            prompt (str): The prompt to generate text from.
+            temperature (float): The temperature setting for generation.
+            steps (int): The number of steps in the generation process.
+            
+        Returns:
+            bool: True if the prediction was successful, False otherwise.
         """
 
         # TODO: (USER) Implement the predict method for inference
-        {% if route.class_data.response %}
-        my_response: {{ route.class_data.response.type }}
-        # TODO: (USER) set the value of my_response based on its type
-        return my_response
-        {% else %}
-        pass
-        {%- endif %}
-
+        # TODO: (USER) set the value of result based on inference logic
+        return f"Executed {prompt} with temperature {temperature} and steps {steps}"
 
 {% endfor %}

--- a/tests/commands/test_initialize.py
+++ b/tests/commands/test_initialize.py
@@ -18,7 +18,7 @@ def clean_config():
     if os.path.exists("cogito.yaml"):
         os.remove("cogito.yaml")
     yield
-    # Cleanup after test3
+    # Cleanup after test
     if os.path.exists("cogito.yaml"):
         os.remove("cogito.yaml")
 
@@ -29,26 +29,42 @@ def test_init_default(runner, clean_config):
     assert "Initializing..." in result.output
     assert os.path.exists("cogito.yaml")
     
-    # Verify config file was created with default values
+    # Verify config file was created with default values as per cogito.yaml
     config = ConfigFile.load_from_file("cogito.yaml")
+    
+    # Server-level defaults
     assert config.cogito.server.name == "Cogito ergo sum"
     assert config.cogito.server.version == "0.1.0"
+    assert config.cogito.server.cache_dir == "/tmp"
+    assert config.cogito.server.description == "Inference server"
+    assert config.cogito.server.threads == 1
+
+    # FastAPI defaults
     assert config.cogito.server.fastapi.host == "0.0.0.0"
     assert config.cogito.server.fastapi.port == 8000
+    assert config.cogito.server.fastapi.access_log is False
+    assert config.cogito.server.fastapi.debug is False
+
+    # Route defaults (note: args and response are no longer present)
+    assert config.cogito.server.route.name == "Predict"
+    assert config.cogito.server.route.description == "Make a single prediction"
+    assert config.cogito.server.route.path == "/v1/predict"
+    assert config.cogito.server.route.predictor == "predict:Predictor"
+    assert config.cogito.server.route.tags == ["predict"]
 
 
 def test_init_prompted(runner, clean_config):
     # Mock user input values
     inputs = [
-        "Test Project",  # name
-        "Test Description",  # description 
-        "0.1.0",  # version
-        "localhost",  # host
-        "8080",  # port
-        "n",  # debug mode
-        "n",  # access log
-        "y",  # add default route
-        "/tmp/cache",  # cache dir
+        "Test Project",         # name
+        "Test Description",     # description 
+        "0.1.0",                # version
+        "localhost",            # host
+        "8080",                 # port
+        "n",                    # debug mode
+        "n",                    # access log
+        "y",                    # add default route
+        "/tmp/cache",           # cache_dir
     ]
     
     result = runner.invoke(init, input="\n".join(inputs))
@@ -66,6 +82,13 @@ def test_init_prompted(runner, clean_config):
     assert config.cogito.server.fastapi.debug is False
     assert config.cogito.server.fastapi.access_log is False
     assert config.cogito.server.cache_dir == "/tmp/cache"
+    
+    # Route defaults remain (since the prompted version still uses the default values)
+    assert config.cogito.server.route.name == "Predict"
+    assert config.cogito.server.route.description == "Make a single prediction"
+    assert config.cogito.server.route.path == "/v1/predict"
+    assert config.cogito.server.route.predictor == "predict:Predictor"
+    assert config.cogito.server.route.tags == ["predict"]
 
 
 def test_init_already_exists(runner, clean_config):

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "cogito"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
# Pull Request: Update Configuration and Prediction Template

## Overview

This PR introduces several key changes to streamline our configuration schema and prediction API interface. We have aligned the defaults used in the CLI initialization with the internal configuration objects and simplified the prediction template.

## Key Changes

### 1. Configuration Schema (`cogito/core/config.py`)
- **Removal of Unused Fields:**  
  The `ArgConfig` and `ResponseConfig` classes (and their corresponding fields `args` and `response` in `RouteConfig`) have been removed.
- **Defaults Alignment:**  
  Updated the default values:
  - Set the server version to `"0.1.0"` and changed `cache_dir` to `"/tmp"`.
  - Adjusted the FastAPI defaults, setting `access_log` to `False`.
- **Impact:**  
  These changes ensure that both the CLI defaults and the configuration objects in `cogito.yaml` share the same values, clarifying their intended use.

### 2. Prediction Template (`cogito/templates/predict_class_template.jinja2`)
- **Explicit Parameter Definition:**  
  Instead of using `*args` and `**kwargs`, the `predict` method now takes:
  - `prompt: str`
  - `temperature: float`
  - `steps: int`
- **Return Value Change:**  
  The method's return type is updated (docstring indicates it should return a `bool`—true if the prediction was successful, false otherwise) and the method documentation has been updated accordingly.
- **Cleanup:**  
  The previous sections for `Args` and `Response` in the template have been removed to reflect the updated configuration.

### 3. Test Enhancements (`tests/commands/test_initialize.py`)
- **Comprehensive Verification:**  
  The tests now assert all properties present in the `cogito.yaml` file:
  - Server settings such as name, version, description, cache directory, and threads.
  - FastAPI settings including host, port, debug, and access_log.
  - Route configurations like name, description, path, predictor, and tags.
- **Consistency Check:**  
  These tests ensure that the defaults provided via the CLI initialization match exactly with the internal configuration objects.

## Diff Summary
