### PR TITLE
feat: Add readiness file support for health checks and application startup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,5 +9,7 @@ repos:
     hooks:
       - id: pytest
         name: Run Pytest
-        entry: make run-test
+        entry: pytest
         language: system
+        pass_filenames: false
+        always_run: true

--- a/cogito/api/handlers.py
+++ b/cogito/api/handlers.py
@@ -4,13 +4,7 @@ from prometheus_client import generate_latest
 
 
 async def health_check_handler(request: Request) -> JSONResponse:
-    if request.app.state.ready:
-        return JSONResponse({"status": "OK"})
-    else:
-        return JSONResponse(
-            {"status": "Starting"},
-            status_code=503,
-        )
+    return JSONResponse({"status": "OK"})
 
 
 async def metrics_handler(request: Request) -> Response:

--- a/cogito/commands/initialize.py
+++ b/cogito/commands/initialize.py
@@ -67,6 +67,13 @@ def _init_prompted() -> ConfigFile:
         show_default=True,
     )
 
+    readyness_file = click.prompt(
+        "Readyness file for health check",
+        type=str,
+        default="/var/lock/cogito-readyness.lock",
+        show_default=True,
+    )
+
     server = ServerConfig(
         name=name,
         description=description,
@@ -75,6 +82,7 @@ def _init_prompted() -> ConfigFile:
         route=route,
         cache_dir=cache_dir,
         threads=1,
+        readyness_file=readyness_file,
     )
 
     click.echo("Almost there! Let's configure the training settings.")
@@ -116,11 +124,13 @@ def _init_prompted() -> ConfigFile:
     help="Force initialization, even if already initialized",
 )
 @click.pass_context
-def init(ctx, scaffold: bool = False, default: bool = False, force: bool = False) -> None:
+def init(
+    ctx, scaffold: bool = False, default: bool = False, force: bool = False
+) -> None:
     """Initialize the project configuration"""
     config_path = ctx.obj.get("config_path", ".") if ctx.obj else "."
     click.echo("Initializing...")
-    
+
     if ConfigFile.exists(f"{config_path}/cogito.yaml") and not force:
         click.echo("Already initialized.")
         return

--- a/cogito/commands/run.py
+++ b/cogito/commands/run.py
@@ -16,7 +16,9 @@ def run(ctx):
     # change cwd to config_path
     os.chdir(absolute_path)
     if not os.path.exists(absolute_path):
-        click.echo(f"Error: Path '{absolute_path}' does not exist.", err=True, color=True)
+        click.echo(
+            f"Error: Path '{absolute_path}' does not exist.", err=True, color=True
+        )
         exit(1)
 
     try:

--- a/cogito/commands/scaffold_predict.py
+++ b/cogito/commands/scaffold_predict.py
@@ -46,11 +46,11 @@ def scaffold_predict_classes(config: ConfigFile, force: bool = False) -> None:
 
 @click.command()
 @click.option(
-        "-f",
-        "--force",
-        is_flag=True,
-        default=False,
-        help="Force overwrite of existing files",
+    "-f",
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Force overwrite of existing files",
 )
 @click.pass_context
 def scaffold(ctx, force: bool = False) -> None:

--- a/cogito/core/app.py
+++ b/cogito/core/app.py
@@ -15,12 +15,24 @@ from cogito.api.handlers import (
 )
 from cogito.api.responses import ErrorResponse
 from cogito.core.config import ConfigFile
-from cogito.core.exceptioin_handlers import (too_many_requests_exception_handler, validation_exception_handler)
-from cogito.core.exceptions import (ConfigFileNotFoundError, NoThreadsAvailableError, SetupError)
+from cogito.core.exceptioin_handlers import (
+    too_many_requests_exception_handler,
+    validation_exception_handler,
+)
+from cogito.core.exceptions import (
+    ConfigFileNotFoundError,
+    NoThreadsAvailableError,
+    SetupError,
+)
 from cogito.core.logging import get_logger
 from cogito.core.models import BasePredictor
-from cogito.core.utils import (create_routes_semaphores, get_predictor_handler_return_type, load_predictor,
-                                wrap_handler, )
+from cogito.core.utils import (
+    create_routes_semaphores,
+    get_predictor_handler_return_type,
+    load_predictor,
+    wrap_handler,
+    readyness_context,
+)
 
 
 class Application:
@@ -28,21 +40,21 @@ class Application:
     ready: bool
 
     def __init__(
-            self,
-            config_file_path: str = ".",
-            logger: Union[Any, logging.Logger] = None,
+        self,
+        config_file_path: str = ".",
+        logger: Union[Any, logging.Logger] = None,
     ):
 
         self._logger = logger or Application._get_default_logger()
 
         try:
             self.config = ConfigFile.load_from_file(
-                    os.path.join(f"{config_file_path}/cogito.yaml")
+                os.path.join(f"{config_file_path}/cogito.yaml")
             )
         except ConfigFileNotFoundError as e:
             self._logger.warning(
-                    "config file does not exist. Using default configuration.",
-                    extra={"error": str(e), "config_file_path": config_file_path},
+                "config file does not exist. Using default configuration.",
+                extra={"error": str(e), "config_file_path": config_file_path},
             )
             self.config = ConfigFile.default()
 
@@ -55,30 +67,30 @@ class Application:
 
         @asynccontextmanager
         async def lifespan(app: FastAPI):
-            task = asyncio.create_task(self.setup(app))
+
             try:
-                await task
-                yield
+                await self.setup(app)
             except SetupError as e:
                 self._logger.critical(
-                        "Unable to start application",
-                        extra={"error": e},
+                    "Unable to start application",
+                    extra={"error": e},
                 )
                 sys.exit(1)
 
+            with readyness_context(self.config.cogito.server.readyness_file):
+                yield
+
         self.app = FastAPI(
-                title=self.config.cogito.server.name,
-                version=self.config.cogito.server.version,
-                description=self.config.cogito.server.description,
-                access_log=self.config.cogito.server.fastapi.access_log,
-                debug=self.config.cogito.server.fastapi.debug,
-                lifespan=lifespan,
+            title=self.config.cogito.server.name,
+            version=self.config.cogito.server.version,
+            description=self.config.cogito.server.description,
+            access_log=self.config.cogito.server.fastapi.access_log,
+            debug=self.config.cogito.server.fastapi.debug,
+            lifespan=lifespan,
         )
 
         # FastAPIInstrumentor.instrument_app(self.app, excluded_urls=",".join(
         #        ["/health-check", "/metrics", "/docs", "/openapi.json"]))
-
-        self.app.state.ready = False
 
         self.app.logger = self._logger
 
@@ -97,58 +109,58 @@ class Application:
             self.map_model_to_instance[route.predictor] = predictor
         else:
             self._logger.info(
-                    "Predictor class already loaded",
-                    extra={"predictor": route.predictor},
+                "Predictor class already loaded",
+                extra={"predictor": route.predictor},
             )
 
         model = self.map_model_to_instance.get(route.predictor)
         response_model = get_predictor_handler_return_type(model)
 
         handler = wrap_handler(
-                descriptor=route.predictor,
-                original_handler=getattr(
-                        self.map_model_to_instance.get(route.predictor), "predict"
-                ),
-                semaphore=semaphores[route.predictor],
-                response_model=response_model,
+            descriptor=route.predictor,
+            original_handler=getattr(
+                self.map_model_to_instance.get(route.predictor), "predict"
+            ),
+            semaphore=semaphores[route.predictor],
+            response_model=response_model,
         )
 
         self.app.add_api_route(
-                route.path,
-                handler,
-                methods=["POST"],
-                name=route.name,
-                description=route.description,
-                tags=route.tags,
-                response_model=response_model,
-                responses={500: {"model": ErrorResponse}},
+            route.path,
+            handler,
+            methods=["POST"],
+            name=route.name,
+            description=route.description,
+            tags=route.tags,
+            response_model=response_model,
+            responses={500: {"model": ErrorResponse}},
         )
 
         self.app.add_exception_handler(
-                RequestValidationError, validation_exception_handler
+            RequestValidationError, validation_exception_handler
         )
         self.app.add_exception_handler(
-                NoThreadsAvailableError, too_many_requests_exception_handler
+            NoThreadsAvailableError, too_many_requests_exception_handler
         )
 
     def _set_default_routes(self) -> None:
         """Include default routes"""
         self.app.add_api_route(
-                "/health-check",
-                health_check_handler,
-                methods=["GET"],
-                name="health_check",
-                description="Health check endpoint",
-                tags=["health"],
+            "/health-check",
+            health_check_handler,
+            methods=["GET"],
+            name="health_check",
+            description="Health check endpoint",
+            tags=["health"],
         )
 
         self.app.add_api_route(
-                "/metrics",
-                metrics_handler,
-                methods=["GET"],
-                name="metrics",
-                description="Metrics endpoint",
-                tags=["metrics"],
+            "/metrics",
+            metrics_handler,
+            methods=["GET"],
+            name="metrics",
+            description="Metrics endpoint",
+            tags=["metrics"],
         )
 
     async def setup(self, app: FastAPI):
@@ -156,23 +168,26 @@ class Application:
         for predictor in self.map_model_to_instance.values():
             try:
                 self._logger.debug(
-                        "Setting up predictor",
-                        extra={"predictor": predictor.__class__.__name__},
+                    "Setting up predictor",
+                    extra={"predictor": predictor.__class__.__name__},
                 )
-                await predictor.setup()
+                # if is courutine
+                if asyncio.iscoroutinefunction(predictor.setup):
+                    await predictor.setup()
+                else:
+                    predictor.setup()
             except Exception as e:
                 self._logger.critical(
-                        "Unable to setting up predictor",
-                        extra={"predictor": predictor.__class__.__name__, "error": e},
+                    "Unable to setting up predictor",
+                    extra={"predictor": predictor.__class__.__name__, "error": e},
                 )
                 raise SetupError(predictor.__class__.__name__, e)
-        app.state.ready = True
 
     def run(self):
         uvicorn.run(
-                self.app,
-                host=self.config.cogito.server.fastapi.host,
-                port=self.config.cogito.server.fastapi.port,
+            self.app,
+            host=self.config.cogito.server.fastapi.host,
+            port=self.config.cogito.server.fastapi.port,
         )
 
     @classmethod

--- a/cogito/core/config.py
+++ b/cogito/core/config.py
@@ -34,21 +34,21 @@ class RouteConfig(BaseModel):
     @classmethod
     def default(cls):
         return cls(
-                name="Predict",
-                description="Make a single prediction",
-                path="/v1/predict",
-                predictor="predict:Predictor",
-                args=[
-                    ArgConfig(
-                            name="prompt",
-                            type="str",
-                            description="The prompt to generate text from",
-                    )
-                ],
-                response=ResponseConfig(
-                        type="PredictResponse", description="The generated text"
-                ),
-                tags=["predict"],
+            name="Predict",
+            description="Make a single prediction",
+            path="/v1/predict",
+            predictor="predict:Predictor",
+            args=[
+                ArgConfig(
+                    name="prompt",
+                    type="str",
+                    description="The prompt to generate text from",
+                )
+            ],
+            response=ResponseConfig(
+                type="PredictResponse", description="The generated text"
+            ),
+            tags=["predict"],
         )
 
 
@@ -75,17 +75,19 @@ class ServerConfig(BaseModel):
     route: Optional[RouteConfig]
     cache_dir: str = None
     threads: Optional[int] = 1
+    readyness_file: str = "/var/lock/cogito-readyness.lock"
 
     @classmethod
     def default(cls):
         return cls(
-                name="Cogito ergo sum",
-                description="Inference server",
-                version="0.1.0",
-                fastapi=FastAPIConfig.default(),
-                route=RouteConfig.default(),
-                cache_dir="/tmp/cogito",
-                threads=1,
+            name="Cogito ergo sum",
+            description="Inference server",
+            version="0.1.0",
+            fastapi=FastAPIConfig.default(),
+            route=RouteConfig.default(),
+            cache_dir="/tmp/cogito",
+            threads=1,
+            readyness_file="/var/lock/cogito-readyness.lock",
         )
 
 
@@ -141,5 +143,9 @@ class ConfigFile(BaseModel):
             raise ValueError(f"Error loading configuration file {file_path}")
 
     def save_to_file(self, file_path: str) -> None:
+        path = Path(file_path)
+        if not path.parent.exists():
+            path.parent.mkdir(parents=True, exist_ok=True)
+
         with open(file_path, "w") as file:
             yaml.dump(self.model_dump(), file)

--- a/cogito/core/utils.py
+++ b/cogito/core/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import contextmanager
 import importlib
 import inspect
 import logging
@@ -186,3 +187,14 @@ async def limit_concurrent_requests(semaphore: asyncio.Semaphore):
         yield  # Ejecuta la lógica de la ruta
     finally:
         semaphore.release()  # Libera el semáforo al finalizar
+
+
+@contextmanager
+def readyness_context(readyness_file: str) -> None:
+    folder = os.path.dirname(readyness_file)
+    os.makedirs(folder, exist_ok=True)
+
+    with open(readyness_file, "w") as f:
+        f.write("ready")
+    yield
+    os.remove(readyness_file)

--- a/examples/cogito.yaml
+++ b/examples/cogito.yaml
@@ -1,5 +1,6 @@
 cogito:
   server:
+    readyness_file: /tmp/cogito-readyness.lock
     cache_dir: /tmp/cogito
     description: Inference server
     threads: 4

--- a/examples/predict.py
+++ b/examples/predict.py
@@ -1,5 +1,5 @@
 import logging
-
+import time
 from pydantic import BaseModel, Field
 
 from cogito import BasePredictor
@@ -12,13 +12,19 @@ class PredictResponse(BaseModel):
 
 class Predictor(BasePredictor):
     def predict(
-            self, prompt: str, temperature: float = Field(0.5,
-                                                          description="Temperature is the most important attribute for an inference",
-                                                          gt=0.0, lt=1.0)
-            ) -> PredictResponse:
+        self,
+        prompt: str,
+        temperature: float = Field(
+            0.5,
+            description="Temperature is the most important attribute for an inference",
+            gt=0.0,
+            lt=1.0,
+        ),
+    ) -> PredictResponse:
         return PredictResponse(
-                image="https://example.com/image.jpg", text="Hello world"
+            image="https://example.com/image.jpg", text="Hello world"
         )
 
     async def setup(self):
+        time.sleep(3)
         logging.info("I'm ready")

--- a/tests/commands/test_initialize.py
+++ b/tests/commands/test_initialize.py
@@ -28,20 +28,21 @@ def test_init_default(runner, clean_config):
     assert result.exit_code == 0
     assert "Initializing..." in result.output
     assert os.path.exists("cogito.yaml")
-    
+
     # Verify config file was created with default values
     config = ConfigFile.load_from_file("cogito.yaml")
     assert config.cogito.server.name == "Cogito ergo sum"
     assert config.cogito.server.version == "0.1.0"
     assert config.cogito.server.fastapi.host == "0.0.0.0"
     assert config.cogito.server.fastapi.port == 8000
+    assert config.cogito.server.readyness_file == "/var/lock/cogito-readyness.lock"
 
 
 def test_init_prompted(runner, clean_config):
     # Mock user input values
     inputs = [
         "Test Project",  # name
-        "Test Description",  # description 
+        "Test Description",  # description
         "0.1.0",  # version
         "localhost",  # host
         "8080",  # port
@@ -49,13 +50,14 @@ def test_init_prompted(runner, clean_config):
         "n",  # access log
         "y",  # add default route
         "/tmp/cache",  # cache dir
+        ".cogito-readyness.lock",  # readyness file
     ]
-    
+
     result = runner.invoke(init, input="\n".join(inputs))
     assert result.exit_code == 0
     assert "Initializing..." in result.output
     assert os.path.exists("cogito.yaml")
-    
+
     # Verify config file was created with prompted values
     config = ConfigFile.load_from_file("cogito.yaml")
     assert config.cogito.server.name == "Test Project"
@@ -66,12 +68,13 @@ def test_init_prompted(runner, clean_config):
     assert config.cogito.server.fastapi.debug is False
     assert config.cogito.server.fastapi.access_log is False
     assert config.cogito.server.cache_dir == "/tmp/cache"
+    assert config.cogito.server.readyness_file == ".cogito-readyness.lock"
 
 
 def test_init_already_exists(runner, clean_config):
     # Create initial config
     runner.invoke(init, ["--default"])
-    
+
     # Try to initialize again
     result = runner.invoke(init)
     assert result.exit_code == 0
@@ -81,7 +84,7 @@ def test_init_already_exists(runner, clean_config):
 def test_init_force(runner, clean_config):
     # Create initial config
     runner.invoke(init, ["--default"])
-    
+
     # Force new initialization
     result = runner.invoke(init, ["--force", "--default"])
     assert result.exit_code == 0

--- a/uv.lock
+++ b/uv.lock
@@ -364,7 +364,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "cogito"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -808,7 +808,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "appnope", marker = "platform_system == 'Darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -2299,7 +2299,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [


### PR DESCRIPTION
- Introduce readyness_file configuration in ServerConfig
- Update health check handler to always return OK status
- Add readyness context manager to create/remove readiness lock file
- Modify initialization command to prompt for readiness file path
- Update setup process to handle both async and sync predictor setup
- Improve platform-specific dependency markers in uv.lock

Adds readiness file support for health checks

Introduces a configurable readiness file for health checks to enhance application startup validations. Updates the health check handler to always return an "OK" status.

Implements a context manager for managing the readiness lock file lifecycle and prompts for the readiness file path during initialization. Enhances the setup process to accommodate both async and sync predictor setups.

Improves package dependency markers in the configuration for better platform compatibility.