### PR TITLE
fix: Fixes predict function return type in jinja template

### DIFF
--- a/cogito/commands/scaffold_predict.py
+++ b/cogito/commands/scaffold_predict.py
@@ -56,7 +56,7 @@ def scaffold_predict_classes(config: ConfigFile, force: bool = False) -> None:
 def scaffold(ctx, force: bool = False) -> None:
     """Generate predict classes"""
 
-    config_path = ctx.obj["config_path"]
+    config_path = ctx.obj.get("config_path", ".") if ctx.obj else "."
 
     click.echo("Generating predict classes...")
 

--- a/cogito/templates/predict_class_template.jinja2
+++ b/cogito/templates/predict_class_template.jinja2
@@ -19,7 +19,7 @@ class {{ route.class_name }}(BasePredictor):
 
         pass
 
-    def predict(self, prompt: str, temperature: float, steps: int) -> string:
+    def predict(self, prompt: str, temperature: float, steps: int) -> str:
         """
 
         # TODO: (USER) Implement the predict method for inference using your parameters


### PR DESCRIPTION
This pull request includes changes to improve the handling of default values and correct type annotations in the `cogito` package. The most important changes include modifying the `scaffold_predict_classes` function to handle missing context objects and correcting the return type annotation in the `predict` method.

Improvements to default value handling:

* [`cogito/commands/scaffold_predict.py`](diffhunk://#diff-8a18b6c2371e1736537664489a4660cce0c1e04533d7725dac4106404e413ed7L59-R59): Modified the `scaffold_predict_classes` function to handle missing context objects by using a default value for `config_path`.

Corrections to type annotations:

* [`cogito/templates/predict_class_template.jinja2`](diffhunk://#diff-562c3f8463955863058c3592a4e1cb566aa42a0d019e313ee68b337567da594bL22-R22): Corrected the return type annotation in the `predict` method from `string` to `str`.