### PR TITLE
fix: changes the default value of readiness file

### DIFF
--- a/cogito/commands/initialize.py
+++ b/cogito/commands/initialize.py
@@ -70,7 +70,7 @@ def _init_prompted() -> ConfigFile:
     readiness_file = click.prompt(
         "Readiness file for health check",
         type=str,
-        default="/var/lock/cogito-readiness.lock",
+        default="$HOME/readiness.lock",
         show_default=True,
     )
 

--- a/cogito/core/config.py
+++ b/cogito/core/config.py
@@ -52,7 +52,7 @@ class ServerConfig(BaseModel):
     route: Optional[RouteConfig]
     cache_dir: str = None
     threads: Optional[int] = 1
-    readiness_file: str = "/var/lock/cogito-readiness.lock"
+    readiness_file: str = "$HOME/readiness.lock"
 
     @classmethod
     def default(cls):
@@ -64,7 +64,7 @@ class ServerConfig(BaseModel):
             route=RouteConfig.default(),
             cache_dir="/tmp",
             threads=1,
-            readiness_file="/var/lock/cogito-readiness.lock",
+            readiness_file="$HOME/readiness.lock",
         )
 
 

--- a/cogito/core/utils.py
+++ b/cogito/core/utils.py
@@ -191,10 +191,11 @@ async def limit_concurrent_requests(semaphore: asyncio.Semaphore):
 
 @contextmanager
 def readiness_context(readiness_file: str) -> None:
-    folder = os.path.dirname(readiness_file)
+    full_readiness_file = os.path.expandvars(os.path.expanduser(readiness_file))
+    folder = os.path.dirname(full_readiness_file)
     os.makedirs(folder, exist_ok=True)
 
-    with open(readiness_file, "w") as f:
+    with open(full_readiness_file, "w") as f:
         f.write("ready")
     yield
-    os.remove(readiness_file)
+    os.remove(full_readiness_file)

--- a/tests/commands/test_initialize.py
+++ b/tests/commands/test_initialize.py
@@ -42,7 +42,8 @@ def test_init_default(runner, clean_config):
     # FastAPI defaults
     assert config.cogito.server.fastapi.host == "0.0.0.0"
     assert config.cogito.server.fastapi.port == 8000
-    assert config.cogito.server.readiness_file == "/var/lock/cogito-readiness.lock"
+    print(f"Readiness file: {config.cogito.server.readiness_file}")
+    assert config.cogito.server.readiness_file == "$HOME/readiness.lock"
     assert config.cogito.server.fastapi.access_log is False
     assert config.cogito.server.fastapi.debug is False
 

--- a/tests/commands/test_initialize.py
+++ b/tests/commands/test_initialize.py
@@ -42,7 +42,6 @@ def test_init_default(runner, clean_config):
     # FastAPI defaults
     assert config.cogito.server.fastapi.host == "0.0.0.0"
     assert config.cogito.server.fastapi.port == 8000
-    print(f"Readiness file: {config.cogito.server.readiness_file}")
     assert config.cogito.server.readiness_file == "$HOME/readiness.lock"
     assert config.cogito.server.fastapi.access_log is False
     assert config.cogito.server.fastapi.debug is False

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "cogito"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This pull request includes changes to update the default path for the readiness file used in the `cogito` project. The default path has been changed from `/var/lock/cogito-readiness.lock` to `$HOME/readiness.lock` in various parts of the codebase.

Key changes include:

* [`cogito/commands/initialize.py`](diffhunk://#diff-45fcaa21cad5eb0994ebae61b1821da1912da70443c2e3563d13fc482ecf8ff3L73-R73): Updated the default value for the readiness file prompt in the `_init_prompted` function.
* [`cogito/core/config.py`](diffhunk://#diff-456946048e87e80631bfef8a4d5a819d6591d2cc1707f85b0fa7c40edaef2c8aL55-R55): Modified the `ServerConfig` class to use the new default readiness file path.
* [`cogito/core/config.py`](diffhunk://#diff-456946048e87e80631bfef8a4d5a819d6591d2cc1707f85b0fa7c40edaef2c8aL67-R67): Updated the `default` class method of `ServerConfig` to reflect the new readiness file path.
* [`tests/commands/test_initialize.py`](diffhunk://#diff-3b4b4194eaac590bd7452a5692750a16c669a1068962a75e2fbd67edc29d80ecL45-R45): Adjusted the test `test_init_default` to check for the new default readiness file path.