### PR TITLE
fix(pyproject.toml): avoid pydantic version requirements in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi>=0.50b0",
     "opentelemetry-sdk>=1.29.0",
     "prometheus-client>=0.21.1",
-    "pydantic>=2.10.5",
+    "pydantic",
     "pyyaml>=6.0.2",
     "structlog>=25.1.0",
     "uvicorn>=0.34.0",


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change removes the version constraint for the `pydantic` dependency.

Dependency update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L29-R29): Removed the version constraint `>=2.10.5` for the `pydantic` dependency.