### PR TITLE
fix: fix error with pydantic1 model_dump function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi>=0.50b0",
     "opentelemetry-sdk>=1.29.0",
     "prometheus-client>=0.21.1",
-    "pydantic",
+    "pydantic>=1.10.0,<3.0.0",
     "pyyaml>=6.0.2",
     "structlog>=25.1.0",
     "uvicorn>=0.34.0",

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "cogito"
-version = "0.2.3"
+version = "0.2.4a0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -414,7 +414,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.50b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.29.0" },
     { name = "prometheus-client", specifier = ">=0.21.1" },
-    { name = "pydantic", specifier = ">=2.10.5" },
+    { name = "pydantic", specifier = ">=1.10.0,<3.0.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "structlog", specifier = ">=25.1.0" },
     { name = "uvicorn", specifier = ">=0.34.0" },


### PR DESCRIPTION
This pull request includes several changes to the `cogito/core/utils.py` file and an update to the `pyproject.toml` file to improve compatibility with different versions of Pydantic and enhance error handling. The most important changes are summarized below:

### Compatibility and Dependency Updates:

* Updated the import statements to support both Pydantic v1 and v2 by using a try-except block to import `Field` from the appropriate module. (`cogito/core/utils.py`)
* Updated the Pydantic dependency version range in `pyproject.toml` to ensure compatibility with versions 1.10.0 to 3.0.0. (`pyproject.toml`)

### Error Handling Improvements:

* Added a check to handle cases where the default value is not an instance of Ellipsis and to extract the default value from `Field` if applicable. (`cogito/core/utils.py`)
* Enhanced the `wrap_handler` function to handle both `model_dump` and `dict` methods for converting input models to dictionaries, ensuring compatibility with different Pydantic model versions. (`cogito/core/utils.py`) [[1]](diffhunk://#diff-ee69b9cc269a282c3abb3a2b50481ecaa38d27b73fc02f217e7545df2f478a5bR95-R102) [[2]](diffhunk://#diff-ee69b9cc269a282c3abb3a2b50481ecaa38d27b73fc02f217e7545df2f478a5bR135-R141)
* Updated the `timed_handler` function to use the correct dictionary input format, ensuring consistent handling of input data. (`cogito/core/utils.py`) [[1]](diffhunk://#diff-ee69b9cc269a282c3abb3a2b50481ecaa38d27b73fc02f217e7545df2f478a5bL99-R115) [[2]](diffhunk://#diff-ee69b9cc269a282c3abb3a2b50481ecaa38d27b73fc02f217e7545df2f478a5bL134-R154)