### PR TITLE
fix(cogito.core.utils): changes the default type from None to Any

### DIFF
--- a/cogito/core/utils.py
+++ b/cogito/core/utils.py
@@ -46,7 +46,7 @@ def load_predictor(class_path) -> Any:
 def get_predictor_handler_return_type(predictor: BasePredictor):
     """This method returns the type of the output of the predictor.predict method"""
     # Get the return type of the predictor.predict method
-    return_type = predictor.predict.__annotations__.get("return", None)
+    return_type = predictor.predict.__annotations__.get("return", Any)
 
     # Create a new dynamic type based on ResultResponse, with the correct module and annotated field
     return_class = type(


### PR DESCRIPTION
This pull request includes a small change to the `cogito/core/utils.py` file. The change modifies the `get_predictor_handler_return_type` method to use `Any` as the default return type for the `predictor.predict` method if no specific return type is annotated.