### PR TITLE
feat: adds version command

### DIFF
--- a/cogito/cli.py
+++ b/cogito/cli.py
@@ -3,6 +3,7 @@ import click
 from cogito.commands.initialize import init
 from cogito.commands.scaffold_predict import scaffold
 from cogito.commands.run import run
+from cogito.commands.version import version
 
 
 @click.group()
@@ -25,6 +26,7 @@ def cli(ctx, config_path: str = ".") -> None:
 cli.add_command(init)
 cli.add_command(scaffold)
 cli.add_command(run)
+cli.add_command(version)
 
 
 def main():

--- a/cogito/commands/version.py
+++ b/cogito/commands/version.py
@@ -13,5 +13,5 @@ def version():
             version = pyproject_data["project"]["version"]
             click.echo(f"Cogito version {version}")
     except Exception as e:
-        click.echo(f"Error al leer la versión: {str(e)}", err=True)
+        click.echo(f"Error reading version: {str(e)}", err=True)
         raise click.Abort()

--- a/cogito/commands/version.py
+++ b/cogito/commands/version.py
@@ -1,0 +1,17 @@
+import click
+import tomli
+from pathlib import Path
+
+
+@click.command()
+def version():
+    """Muestra la versión actual de Cogito."""
+    try:
+        pyproject_path = Path(__file__).parent.parent.parent / "pyproject.toml"
+        with open(pyproject_path, "rb") as f:
+            pyproject_data = tomli.load(f)
+            version = pyproject_data["project"]["version"]
+            click.echo(f"Cogito version {version}")
+    except Exception as e:
+        click.echo(f"Error al leer la versión: {str(e)}", err=True)
+        raise click.Abort()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "pydantic>=1.10.0,<3.0.0",
     "pyyaml>=6.0.2",
     "structlog>=25.1.0",
+    "tomli>=2.0.1",
     "uvicorn>=0.34.0",
 ]
 


### PR DESCRIPTION
This pull request introduces a new command to display the current version of the Cogito application and includes necessary changes to support this command.

### Addition of version command:

* [`cogito/cli.py`](diffhunk://#diff-ee6318a1269bf0356c7a729bc31185269fbb8a9c5c924305de7b2cd545aa8880R6): Imported the `version` command and added it to the CLI commands. [[1]](diffhunk://#diff-ee6318a1269bf0356c7a729bc31185269fbb8a9c5c924305de7b2cd545aa8880R6) [[2]](diffhunk://#diff-ee6318a1269bf0356c7a729bc31185269fbb8a9c5c924305de7b2cd545aa8880R29)
* [`cogito/commands/version.py`](diffhunk://#diff-c5b0d9ef6b2fc10c26086aabe5474f4b3841425329c042417668c96ca2906f90R1-R17): Created a new command `version` that reads the version from `pyproject.toml` and displays it.

### Dependency update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R32): Added `tomli` as a dependency to parse the `pyproject.toml` file.