### PR TITLE
53 cli command to run predictions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: pytest
         name: Run Pytest
-        entry: pytest
+        entry: .venv/bin/pytest
         language: system
         pass_filenames: false
         always_run: true

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ run-test: .venv dependencies-dev-install ## Run the tests
 ##@ Install
 
 install: ## Install the package
-	@pip install -e .
+	@. .venv/bin/activate && pip install -e .
 
 ##@ Release commands
 

--- a/cogito/cli.py
+++ b/cogito/cli.py
@@ -3,6 +3,7 @@ import click
 from cogito.commands.initialize import init
 from cogito.commands.scaffold_predict import scaffold
 from cogito.commands.run import run
+from cogito.commands.predict import predict
 from cogito.commands.version import version
 
 
@@ -11,7 +12,7 @@ from cogito.commands.version import version
     "-c",
     "--config-path",
     type=str,
-    default=".",
+    default="./cogito.yaml",
     help="The path to the configuration file",
 )
 @click.pass_context
@@ -26,6 +27,7 @@ def cli(ctx, config_path: str = ".") -> None:
 cli.add_command(init)
 cli.add_command(scaffold)
 cli.add_command(run)
+cli.add_command(predict)
 cli.add_command(version)
 
 

--- a/cogito/commands/initialize.py
+++ b/cogito/commands/initialize.py
@@ -128,10 +128,12 @@ def init(
     ctx, scaffold: bool = False, default: bool = False, force: bool = False
 ) -> None:
     """Initialize the project configuration"""
-    config_path = ctx.obj.get("config_path", ".") if ctx.obj else "."
+    config_path = (
+        ctx.obj.get("config_path", "./cogito.yaml") if ctx.obj else "./cogito.yaml"
+    )
     click.echo("Initializing...")
 
-    if ConfigFile.exists(f"{config_path}/cogito.yaml") and not force:
+    if ConfigFile.exists(f"{config_path}") and not force:
         click.echo("Already initialized.")
         return
 
@@ -143,5 +145,5 @@ def init(
     if scaffold:
         scaffold_predict_classes(config, force)
 
-    config.save_to_file(f"{config_path}/cogito.yaml")
+    config.save_to_file(f"{config_path}")
     click.echo("Initialized successfully.")

--- a/cogito/commands/predict.py
+++ b/cogito/commands/predict.py
@@ -1,0 +1,48 @@
+import json
+import os
+import sys
+
+import click
+
+from cogito.core.config import ConfigFile
+from cogito.core.exceptions import ConfigFileNotFoundError
+from cogito.core.utils import load_predictor
+
+
+@click.command()
+@click.option(
+    "--payload", type=str, required=True, help="The payload for the prediction"
+)
+@click.pass_obj
+def predict(ctx, payload):
+    """
+    Run a cogito prediction with the specified payload, printing the result to stdout.
+
+    Example: python -m cogito.cli predict --payload '{"key": "value"}'
+    """
+    config_path = ctx.get("config_path")
+    app_dir = os.path.dirname(os.path.abspath(config_path))
+    try:
+        config = ConfigFile.load_from_file(f"{config_path}")
+    except ConfigFileNotFoundError:
+        click.echo("No configuration file found. Please initialize the project first.")
+        exit(1)
+
+    try:
+        sys.path.insert(0, app_dir)
+        predictor = config.cogito.server.route.predictor
+        predictor_instance = load_predictor(predictor)
+
+        payload_data = json.loads(payload)
+        result = predictor_instance.predict(**payload_data)
+
+        if isinstance(result, str):
+            click.echo(result)
+        else:
+            try:
+                click.echo(json.dumps(result, indent=4))
+            except TypeError:
+                click.echo(json.dumps(result.__dict__, indent=4))
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True, color=True)
+        exit(1)

--- a/cogito/commands/scaffold_predict.py
+++ b/cogito/commands/scaffold_predict.py
@@ -60,9 +60,8 @@ def scaffold(ctx, force: bool = False) -> None:
 
     click.echo("Generating predict classes...")
 
-    # TODO: cogito.yaml file name should not be mandatory in the application
     try:
-        config = ConfigFile.load_from_file(f"{config_path}/cogito.yaml")
+        config = ConfigFile.load_from_file(f"{config_path}")
     except ConfigFileNotFoundError:
         click.echo("No configuration file found. Please initialize the project first.")
         return

--- a/cogito/core/app.py
+++ b/cogito/core/app.py
@@ -41,16 +41,14 @@ class Application:
 
     def __init__(
         self,
-        config_file_path: str = ".",
+        config_file_path: str = "./cogito.yaml",
         logger: Union[Any, logging.Logger] = None,
     ):
 
         self._logger = logger or Application._get_default_logger()
 
         try:
-            self.config = ConfigFile.load_from_file(
-                os.path.join(f"{config_file_path}/cogito.yaml")
-            )
+            self.config = ConfigFile.load_from_file(os.path.join(f"{config_file_path}"))
         except ConfigFileNotFoundError as e:
             self._logger.warning(
                 "config file does not exist. Using default configuration.",

--- a/examples/cogito.yaml
+++ b/examples/cogito.yaml
@@ -11,10 +11,6 @@ cogito:
       port: 8000
     name: Cogito ergo sum
     route:
-      args:
-        - description: The prompt to generate text from
-          name: prompt
-          type: str
       description: Make a single prediction
       name: Predict
       path: /v1/predict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 click==8.1.8
 fastapi==0.115.6
+google-cloud-storage==3.0.0
+huggingface-hub==0.29.1
 jinja2==3.1.5
 opentelemetry-exporter-prometheus==0.50b0
 opentelemetry-instrumentation-fastapi==0.50b0
@@ -8,4 +10,5 @@ prometheus-client==0.21.1
 pydantic==2.10.5
 pyyaml==6.0.2
 structlog==25.1.0
+tomli==2.2.1
 uvicorn==0.34.0

--- a/tests/commands/test_initialize.py
+++ b/tests/commands/test_initialize.py
@@ -27,10 +27,10 @@ def test_init_default(runner, clean_config):
     result = runner.invoke(init, ["--default"])
     assert result.exit_code == 0
     assert "Initializing..." in result.output
-    assert os.path.exists("cogito.yaml")
+    assert os.path.exists("./cogito.yaml")
 
     # Verify config file was created with default values as per cogito.yaml
-    config = ConfigFile.load_from_file("cogito.yaml")
+    config = ConfigFile.load_from_file("./cogito.yaml")
 
     # Server-level defaults
     assert config.cogito.server.name == "Cogito ergo sum"
@@ -75,7 +75,7 @@ def test_init_prompted(runner, clean_config):
     assert os.path.exists("cogito.yaml")
 
     # Verify config file was created with prompted values
-    config = ConfigFile.load_from_file("cogito.yaml")
+    config = ConfigFile.load_from_file("./cogito.yaml")
     assert config.cogito.server.name == "Test Project"
     assert config.cogito.server.description == "Test Description"
     assert config.cogito.server.version == "0.1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -364,7 +364,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "cogito"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -810,7 +810,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_system == 'Darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -2301,7 +2301,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [


### PR DESCRIPTION
This pull request includes several updates to the `cogito` project to improve configuration handling and add a new prediction command. The most significant changes involve updating the default configuration path, adding a new `predict` command, and ensuring compatibility with virtual environments.

### Configuration Handling Improvements:

* Updated the default configuration path from `.` to `./cogito.yaml` throughout the project to ensure consistency and clarity. This change affects multiple files including `cogito/cli.py`, `cogito/commands/initialize.py`, `cogito/commands/scaffold_predict.py`, `cogito/core/app.py`, and test files. [[1]](diffhunk://#diff-ee6318a1269bf0356c7a729bc31185269fbb8a9c5c924305de7b2cd545aa8880L14-R15) [[2]](diffhunk://#diff-45fcaa21cad5eb0994ebae61b1821da1912da70443c2e3563d13fc482ecf8ff3L131-R136) [[3]](diffhunk://#diff-45fcaa21cad5eb0994ebae61b1821da1912da70443c2e3563d13fc482ecf8ff3L146-R148) [[4]](diffhunk://#diff-8a18b6c2371e1736537664489a4660cce0c1e04533d7725dac4106404e413ed7L63-R64) [[5]](diffhunk://#diff-a1174d8945fa2a12721fbd85c4d5479be3d8c134344d353169b2f062d0997d39L44-R51) [[6]](diffhunk://#diff-3b4b4194eaac590bd7452a5692750a16c669a1068962a75e2fbd67edc29d80ecL30-R33) [[7]](diffhunk://#diff-3b4b4194eaac590bd7452a5692750a16c669a1068962a75e2fbd67edc29d80ecL78-R78)

### New Prediction Command:

* Added a new `predict` command to the CLI, which allows users to run a prediction using a specified payload. This command is implemented in `cogito/commands/predict.py` and integrated into the CLI in `cogito/cli.py`. [[1]](diffhunk://#diff-b3e11ee41072385edbcb651f416ac876ca12256bef150bd296d4cfce9b5cbc36R1-R48) [[2]](diffhunk://#diff-ee6318a1269bf0356c7a729bc31185269fbb8a9c5c924305de7b2cd545aa8880R6) [[3]](diffhunk://#diff-ee6318a1269bf0356c7a729bc31185269fbb8a9c5c924305de7b2cd545aa8880R30)

### Virtual Environment Compatibility:

* Modified the `.pre-commit-config.yaml` and `Makefile` to ensure compatibility with virtual environments by specifying the path to the `pytest` and activating the virtual environment before running `pip install`. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L12-R12) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L82-R82)

### Miscellaneous:

* Removed unnecessary arguments from the example configuration file `examples/cogito.yaml` to simplify the configuration.