### PR TITLE
Predict command setup launch

### DIFF
--- a/cogito/commands/predict.py
+++ b/cogito/commands/predict.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import sys
@@ -34,24 +35,35 @@ def predict(ctx, payload):
         exit(1)
 
     try:
+        # Load predictor instance using the path to the cogito.yaml file
         sys.path.insert(0, app_dir)
         predictor = config.cogito.server.route.predictor
         predictor_instance = load_predictor(predictor)
 
+        # Run setup method asynchronously
+        asyncio.run(predictor_instance.setup())
+
+        # Create input model from payload
         payload_data = json.loads(payload)
         _, input_model_class = create_request_model(
             predictor, predictor_instance.predict
         )
         input_model = input_model_class(**payload_data)
 
+        # Get response model type
         response_model = get_predictor_handler_return_type(predictor_instance)
 
+        # Wrap handler with response model
         handler = wrap_handler(
             descriptor=predictor,
             original_handler=predictor_instance.predict,
             response_model=response_model,
         )
+
+        # Call handler with input model
         response = handler(input_model)
+
+        # Print response in JSON format
         click.echo(response.model_dump_json(indent=4))
     except Exception as e:
         # print stack trace

--- a/uv.lock
+++ b/uv.lock
@@ -373,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "cogito"
-version = "0.2.5"
+version = "0.2.6a0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This pull request introduces asynchronous setup for the predictor in the `predict` command and enhances the corresponding tests to ensure proper functionality. The key changes include importing the `asyncio` module, modifying the `predict` function to run the setup method asynchronously, and updating the tests to verify the setup process.

### Changes to `predict` command:

* Added import for `asyncio` module in `cogito/commands/predict.py` to support asynchronous operations.
* Updated `predict` function to run the predictor's setup method asynchronously using `asyncio.run`.

### Changes to tests:

* Added `setup` method to `MockPredictor` class in `tests/commands/test_predict_command.py` to mock resource initialization.
* Added a spy to the `setup` method in the `setUp` method to track its invocation.
* Verified that the `setup` method is called in the `test_predict_command_success` test.
* Added a new test `test_predict_command_setup_error` to handle and verify setup errors.