### PR TITLE
feat: Implements BadRequestError raising and 400 error code response

### DIFF
--- a/cogito/api/responses.py
+++ b/cogito/api/responses.py
@@ -15,3 +15,10 @@ class ErrorResponse(BaseModel):
 
     def to_json_response(self) -> JSONResponse:
         return JSONResponse(status_code=500, content=self.model_dump())
+
+
+class BadRequestResponse(BaseModel):
+    message: str
+
+    def to_json_response(self) -> JSONResponse:
+        return JSONResponse(status_code=400, content=self.model_dump())

--- a/cogito/commands/run.py
+++ b/cogito/commands/run.py
@@ -11,19 +11,23 @@ from cogito import Application
 def run(ctx):
     """Run cogito app"""
     config_path = ctx.get("config_path")
-    absolute_path = os.path.abspath(config_path)
-    click.echo(f"Running '{absolute_path}' cogito application...")
-    # change cwd to config_path
-    os.chdir(absolute_path)
-    if not os.path.exists(absolute_path):
+    config_absolute_path = os.path.abspath(config_path)
+    click.echo(f"Running '{config_absolute_path}' cogito application...")
+
+    config_dir_absolute_path = os.path.dirname(config_absolute_path)
+    os.chdir(config_dir_absolute_path)
+
+    if not os.path.exists(config_absolute_path):
         click.echo(
-            f"Error: Path '{absolute_path}' does not exist.", err=True, color=True
+            f"Error: Path '{config_absolute_path}' does not exist.",
+            err=True,
+            color=True,
         )
         exit(1)
 
     try:
-        sys.path.insert(0, absolute_path)
-        app = Application(config_file_path=absolute_path)
+        sys.path.insert(0, config_dir_absolute_path)
+        app = Application(config_file_path=config_absolute_path)
         app.run()
     except Exception as e:
         click.echo(f"Error: {e}", err=True, color=True)

--- a/cogito/core/app.py
+++ b/cogito/core/app.py
@@ -13,13 +13,18 @@ from cogito.api.handlers import (
     health_check_handler,
     metrics_handler,
 )
-from cogito.api.responses import ErrorResponse
+from cogito.api.responses import (
+    ErrorResponse,
+    BadRequestResponse,
+)
 from cogito.core.config import ConfigFile
 from cogito.core.exceptioin_handlers import (
+    bad_request_exception_handler,
     too_many_requests_exception_handler,
     validation_exception_handler,
 )
 from cogito.core.exceptions import (
+    BadRequestError,
     ConfigFileNotFoundError,
     NoThreadsAvailableError,
     SetupError,
@@ -131,9 +136,13 @@ class Application:
             description=route.description,
             tags=route.tags,
             response_model=response_model,
-            responses={500: {"model": ErrorResponse}},
+            responses={
+                500: {"model": ErrorResponse},
+                400: {"model": BadRequestResponse},
+            },
         )
 
+        self.app.add_exception_handler(BadRequestError, bad_request_exception_handler)
         self.app.add_exception_handler(
             RequestValidationError, validation_exception_handler
         )

--- a/cogito/core/exceptioin_handlers.py
+++ b/cogito/core/exceptioin_handlers.py
@@ -3,7 +3,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
 
-from cogito.core.exceptions import NoThreadsAvailableError
+from cogito.core.exceptions import NoThreadsAvailableError, BadRequestError
 
 
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
@@ -27,6 +27,19 @@ async def too_many_requests_exception_handler(
         content=jsonable_encoder(
             {
                 "detail": "There are no threads available to process the request.",
+            }
+        ),
+    )
+
+
+async def bad_request_exception_handler(
+    request: Request, exc: BadRequestError
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        content=jsonable_encoder(
+            {
+                "detail": exc.message,
             }
         ),
     )

--- a/cogito/core/exceptions.py
+++ b/cogito/core/exceptions.py
@@ -21,3 +21,9 @@ class ModelDownloadError(Exception):
 class NoThreadsAvailableError(Exception):
     def __init__(self, class_name: str):
         super().__init__(f"No threads available for {class_name}")
+
+
+class BadRequestError(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message

--- a/cogito/core/utils.py
+++ b/cogito/core/utils.py
@@ -19,7 +19,11 @@ from pydantic import create_model
 
 from cogito.api.responses import ErrorResponse, ResultResponse
 from cogito.core.config import CogitoConfig
-from cogito.core.exceptions import ModelDownloadError, NoThreadsAvailableError
+from cogito.core.exceptions import (
+    ModelDownloadError,
+    NoThreadsAvailableError,
+    BadRequestError,
+)
 from cogito.core.metrics import inference_duration_histogram
 from cogito.core.model_store import download_gcp_model, download_huggingface_model
 from cogito.core.models import BasePredictor
@@ -92,6 +96,8 @@ def wrap_handler(
                         end_time * 1000, {"predictor": class_name, "async": True}
                     )
                     # todo Count successful requests
+                except BadRequestError as e:
+                    raise
                 except Exception as e:
                     logging.exception(e)
                     # todo Count failed requests
@@ -131,6 +137,8 @@ def wrap_handler(
                         end_time * 1000, {"predictor": class_name, "async": False}
                     )
                     # todo Count successful requests
+                except BadRequestError as e:
+                    raise
                 except Exception as e:
                     logging.exception(e)
                     # todo Count failed requests

--- a/cogito/exceptions.py
+++ b/cogito/exceptions.py
@@ -1,0 +1,3 @@
+from cogito.core.exceptions import BadRequestError
+
+__all__ = ["BadRequestError"]

--- a/tests/commands/test_scaffold_predict.py
+++ b/tests/commands/test_scaffold_predict.py
@@ -1,0 +1,142 @@
+import os
+import pytest
+from unittest.mock import patch, mock_open, MagicMock
+
+from cogito.commands.scaffold_predict import scaffold_predict_classes
+from cogito.core.config import (
+    ConfigFile,
+    RouteConfig,
+    ServerConfig,
+    CogitoConfig,
+    FastAPIConfig,
+)
+
+
+@pytest.fixture
+def mock_config():
+    route = RouteConfig(
+        name="Test Prediction",
+        path="/v1/predict",
+        predictor="predict.py:PredictClass",
+        input_schema={"type": "object", "properties": {}},
+        output_schema={"type": "object", "properties": {}},
+    )
+    server = ServerConfig(
+        route=route,
+        name="Test Server",
+        description="Test Server Description",
+        version="1.0.0",
+        fastapi=FastAPIConfig(host="0.0.0.0", port=8000, debug=False, access_log=False),
+    )
+    cogito = CogitoConfig(server=server, trainer="trainer.py:TrainerClass")
+    return ConfigFile(
+        cogito=cogito,
+    )
+
+
+@pytest.fixture
+def mock_template():
+    return """
+class {{ route.class_name }}:
+    def predict(self, input_data: dict) -> dict:
+        return {}
+"""
+
+
+def test_scaffold_predict_classes_creates_new_file(mock_config, tmp_path):
+    """Test que verifica la creación de un nuevo archivo de predicción."""
+    # Guardar el directorio original
+    original_dir = os.getcwd()
+
+    try:
+        # Cambiar al directorio temporal
+        os.chdir(tmp_path)
+
+        with patch("cogito.commands.scaffold_predict.Environment") as mock_env:
+            # Configurar el mock del template
+            mock_template = MagicMock()
+            mock_template.render.return_value = "class PredictClass:\n    pass\n"
+            mock_env.return_value.get_template.return_value = mock_template
+
+            # Ejecutar la función (sin mockear open para que realmente cree el archivo)
+            scaffold_predict_classes(mock_config)
+
+            # Verificar que el archivo fue creado (usando la ruta correcta)
+            file_path = os.path.join(tmp_path, "predict.py.py")
+            assert os.path.exists(file_path)
+
+            # Verificar el contenido del archivo
+            with open(file_path, "r") as f:
+                content = f.read()
+                assert "class PredictClass:" in content
+    finally:
+        # Restaurar el directorio original
+        os.chdir(original_dir)
+
+
+def test_scaffold_predict_classes_force_overwrite(mock_config, tmp_path):
+    """Test que verifica la sobrescritura de archivos existentes con --force."""
+    # Guardar el directorio original
+    original_dir = os.getcwd()
+
+    try:
+        # Cambiar al directorio temporal
+        os.chdir(tmp_path)
+
+        with patch("cogito.commands.scaffold_predict.Environment") as mock_env:
+            # Configurar el mock del template
+            mock_template = MagicMock()
+            mock_template.render.return_value = "class PredictClass:\n    pass\n"
+            mock_env.return_value.get_template.return_value = mock_template
+
+            # Crear un archivo existente con el nombre correcto
+            with open("predict.py.py", "w") as f:
+                f.write("# Existing content")
+
+            # Ejecutar la función con force=True
+            scaffold_predict_classes(mock_config, force=True)
+
+            # Verificar que el archivo fue sobrescrito
+            with open("predict.py.py", "r") as f:
+                content = f.read()
+                assert "class PredictClass:" in content
+                assert "# Existing content" not in content
+    finally:
+        # Restaurar el directorio original
+        os.chdir(original_dir)
+
+
+def test_scaffold_predict_classes_no_force_existing_file(mock_config, tmp_path, capsys):
+    """Test que verifica que no se sobrescriben archivos sin --force."""
+    # Guardar el directorio original
+    original_dir = os.getcwd()
+
+    try:
+        # Cambiar al directorio temporal
+        os.chdir(tmp_path)
+
+        with patch("cogito.commands.scaffold_predict.Environment") as mock_env:
+            # Configurar el mock del template
+            mock_template = MagicMock()
+            mock_template.render.return_value = "class PredictClass:\n    pass\n"
+            mock_env.return_value.get_template.return_value = mock_template
+
+            # Crear un archivo existente con el nombre correcto (predict.py.py)
+            existing_content = "# Existing content"
+            with open("predict.py.py", "w") as f:
+                f.write(existing_content)
+
+            # Ejecutar la función sin force
+            scaffold_predict_classes(mock_config, force=False)
+
+            # Verificar que el archivo mantiene su contenido original
+            with open("predict.py.py", "r") as f:
+                content = f.read()
+                assert content == existing_content
+
+            # Verificar el mensaje de advertencia
+            captured = capsys.readouterr()
+            assert "File predict.py.py already exists" in captured.out
+    finally:
+        # Restaurar el directorio original
+        os.chdir(original_dir)


### PR DESCRIPTION
This pull request introduces several important changes to improve error handling, refactor code for better readability, and add new tests for the `scaffold_predict_classes` function. The key changes include adding a new `BadRequestResponse` class, updating exception handling, and enhancing the `run` command.

### Error Handling Improvements:
* Added `BadRequestResponse` class to handle 400 error responses in `cogito/api/responses.py`.
* Updated `cogito/core/app.py` to include `BadRequestResponse` and `bad_request_exception_handler`. [[1]](diffhunk://#diff-a1174d8945fa2a12721fbd85c4d5479be3d8c134344d353169b2f062d0997d39L16-R27) [[2]](diffhunk://#diff-a1174d8945fa2a12721fbd85c4d5479be3d8c134344d353169b2f062d0997d39L134-R145)
* Added `BadRequestError` exception class in `cogito/core/exceptions.py` and corresponding handler in `cogito/core/exceptioin_handlers.py`. [[1]](diffhunk://#diff-66d430bc591692911ed05db565ec2156d134e4d95c5dbd1a64a0506f4b082888R24-R29) [[2]](diffhunk://#diff-70791761a9cf1477d2d0b49ef5868c000ac7c9a73d5c3fb4e537d888a769c00aR33-R45)

### Code Refactoring:
* Refactored `run` command in `cogito/commands/run.py` for better readability and maintainability.

### Testing Enhancements:
* Added tests for `scaffold_predict_classes` function in `tests/commands/test_scaffold_predict.py`.

These changes collectively improve the robustness, readability, and test coverage of the codebase.