### PR TITLE
fix: Upgrades python-json-logger to 3.3.0 or higher due to security

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
     "structlog>=25.1.0",
     "tomli>=2.0.1",
     "uvicorn>=0.34.0",
+    # forces python-json-logger>=3.3.0 due to a security bug https://nvd.nist.gov/vuln/detail/CVE-2025-27607
+    "python-json-logger>=3.3.0",
 ]
 
 [dependency-groups]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ opentelemetry-instrumentation-fastapi==0.50b0
 opentelemetry-sdk==1.29.0
 prometheus-client==0.21.1
 pydantic==2.10.5
+python-json-logger==3.3.0
 pyyaml==6.0.2
 structlog==25.1.0
 tomli==2.2.1

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.13'",
@@ -373,7 +374,7 @@ wheels = [
 
 [[package]]
 name = "cogito"
-version = "0.2.6a3"
+version = "0.2.6a4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -386,6 +387,7 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "prometheus-client" },
     { name = "pydantic" },
+    { name = "python-json-logger" },
     { name = "pyyaml" },
     { name = "structlog" },
     { name = "tomli" },
@@ -416,6 +418,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = ">=1.29.0" },
     { name = "prometheus-client", specifier = ">=0.21.1" },
     { name = "pydantic", specifier = ">=1.10.0,<3.0.0" },
+    { name = "python-json-logger", specifier = ">=3.3.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "structlog", specifier = ">=25.1.0" },
     { name = "tomli", specifier = ">=2.0.1" },
@@ -1828,11 +1831,11 @@ wheels = [
 
 [[package]]
 name = "python-json-logger"
-version = "3.2.1"
+version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/c4/358cd13daa1d912ef795010897a483ab2f0b41c9ea1b35235a8b2f7d15a7/python_json_logger-3.2.1.tar.gz", hash = "sha256:8eb0554ea17cb75b05d2848bc14fb02fbdbd9d6972120781b974380bfa162008", size = 16287 }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/de/d3144a0bceede957f961e975f3752760fbe390d57fbe194baf709d8f1f7b/python_json_logger-3.3.0.tar.gz", hash = "sha256:12b7e74b17775e7d565129296105bbe3910842d9d0eb083fc83a6a617aa8df84", size = 16642 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/72/2f30cf26664fcfa0bd8ec5ee62ec90c03bd485e4a294d92aabc76c5203a5/python_json_logger-3.2.1-py3-none-any.whl", hash = "sha256:cdc17047eb5374bd311e748b42f99d71223f3b0e186f4206cc5d52aefe85b090", size = 14924 },
+    { url = "https://files.pythonhosted.org/packages/08/20/0f2523b9e50a8052bc6a8b732dfc8568abbdc42010aef03a2d750bdab3b2/python_json_logger-3.3.0-py3-none-any.whl", hash = "sha256:dd980fae8cffb24c13caf6e158d3d61c0d6d22342f932cb6e9deedab3d35eec7", size = 15163 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request includes an important update to the `pyproject.toml` file to address a security vulnerability. The most significant change is the addition of a new dependency to ensure the application uses a secure version of `python-json-logger`.

Security update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R34-R35): Added `python-json-logger>=3.3.0` to the dependencies to address a security vulnerability (CVE-2025-27607).… issue