### PR TITLE
102 bug configuration upgrade fails due to missing config version field

### DIFF
--- a/cogito/core/config/file.py
+++ b/cogito/core/config/file.py
@@ -12,6 +12,7 @@ from cogito.core.exceptions import ConfigFileNotFoundError
 
 # Constants
 DEFAULT_CONFIG_VERSION = 1
+NO_CONFIG_VERSION = 0
 
 # Configuration version mapping
 CONFIG_VERSION_MAP: Dict[int, str] = {
@@ -65,7 +66,7 @@ class ConfigFile(BaseModel):
                 yaml_data = yaml.safe_load(file)
 
                 if "config_version" not in yaml_data:
-                    yaml_data["config_version"] = DEFAULT_CONFIG_VERSION
+                    yaml_data["config_version"] = NO_CONFIG_VERSION
 
                 cogito_data = yaml_data.get("cogito", {})
                 config_version = yaml_data["config_version"]

--- a/cogito/core/config/file.py
+++ b/cogito/core/config/file.py
@@ -78,8 +78,8 @@ class ConfigFile(BaseModel):
                 return cls(**yaml_data)
         except FileNotFoundError:
             raise ConfigFileNotFoundError(file_path)
-        except Exception:
-            raise ValueError(f"Error loading configuration file {file_path}")
+        except Exception as e:
+            raise ValueError(f"Error loading configuration file {file_path}: {e}")
 
     def save_to_file(self, file_path: str) -> None:
         """Save the configuration to a file."""


### PR DESCRIPTION
This pull request includes changes to the `cogito/core/config/file.py` file to improve error handling and configuration version management. The most important changes are:

Configuration version management:

* Added a new constant `NO_CONFIG_VERSION` to represent a configuration with no version.
* Updated the `load_from_file` method to use `NO_CONFIG_VERSION` when `config_version` is not present in the YAML data.

Error handling:

* Enhanced the exception handling in the `load_from_file` method to include the original exception message in the raised `ValueError`.