### PR TITLE
101 bug indexerror list index out of range in scaffold train classes

### DIFF
--- a/cogito/templates/predict_class_template.jinja2
+++ b/cogito/templates/predict_class_template.jinja2
@@ -10,7 +10,7 @@ class {{ route.class_name }}(BasePredictor):
     Tags: {{ route.class_data.tags }}
     """
 
-    async def setup(self):
+    def setup(self):
         """
         This method is called once before the first prediction is made.
         """

--- a/cogito/templates/train_class_template.jinja2
+++ b/cogito/templates/train_class_template.jinja2
@@ -3,7 +3,7 @@ from cogito.core.models import BaseTrainer
 {% for route in routes %}
 class {{ route.class_name }}(BaseTrainer):
 
-    async def setup(self):
+    def setup(self):
         """
         This method is called once before training begins.
         """

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "cogito"
-version = "0.3.0a1"
+version = "0.3.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This pull request includes several changes to the `cogito/commands/scaffold.py` file and updates to the Jinja2 templates for predict and train classes. The primary focus is on improving error handling and modifying the behavior of the `setup` method in the templates.

Error handling improvements:

* [`cogito/commands/scaffold.py`](diffhunk://#diff-40bb8f73fa614a7880339aac63293c1bf042a557919c3c31d358c447dc8001dcL46-R46): Changed the return type of `scaffold_train_classes` from `None` to `bool` and added checks to ensure a trainer is defined in the config file. If not, an error message is displayed, and the function returns `False`. The function now returns `True` upon successful completion. [[1]](diffhunk://#diff-40bb8f73fa614a7880339aac63293c1bf042a557919c3c31d358c447dc8001dcL46-R46) [[2]](diffhunk://#diff-40bb8f73fa614a7880339aac63293c1bf042a557919c3c31d358c447dc8001dcR59-R64) [[3]](diffhunk://#diff-40bb8f73fa614a7880339aac63293c1bf042a557919c3c31d358c447dc8001dcR88-R89)
* [`cogito/commands/scaffold.py`](diffhunk://#diff-40bb8f73fa614a7880339aac63293c1bf042a557919c3c31d358c447dc8001dcL113-R136): Updated the `scaffold` function to use `exit(1)` instead of `return` for error cases, ensuring the script exits with an error status. Additionally, if `scaffold_train_classes` returns `False`, the script exits with an error status.

Template modifications:

* [`cogito/templates/predict_class_template.jinja2`](diffhunk://#diff-562c3f8463955863058c3592a4e1cb566aa42a0d019e313ee68b337567da594bL13-R13): Changed the `setup` method from `async` to synchronous to match the expected behavior.
* [`cogito/templates/train_class_template.jinja2`](diffhunk://#diff-cd4d98b7c5724f5f18f908cdfcce015e1f9e3be4309c0e66dc6224c694b9db90L6-R6): Changed the `setup` method from `async` to synchronous to match the expected behavior.