### PR TITLE
feat(ci): Add testing job to GitHub Actions workflow for PyPI publishing

### DIFF
--- a/.github/workflows/publish-to-pypi-and-test-pypi.yml
+++ b/.github/workflows/publish-to-pypi-and-test-pypi.yml
@@ -3,6 +3,29 @@ name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 on: push
 
 jobs:
+
+  test:
+    name: Run Python Tests before publishing
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+          pip install pytest
+
+      - name: Run tests using Makefile target
+        run: python -m pytest
+
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
@@ -26,7 +49,6 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
-
 
   github-release:
     name: >-
@@ -71,7 +93,6 @@ jobs:
         '${{ github.ref_name }}' dist/**
         --repo '${{ github.repository }}'
 
-
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
@@ -92,7 +113,6 @@ jobs:
         path: dist/
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-
 
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI

--- a/.github/workflows/publish-to-pypi-and-test-pypi.yml
+++ b/.github/workflows/publish-to-pypi-and-test-pypi.yml
@@ -28,7 +28,8 @@ jobs:
 
   build:
     name: Build distribution 📦
-    needs: [test]  # Make build depend on successful test completion
+    needs: 
+      - test  # Make build depend on successful test completion
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-to-pypi-and-test-pypi.yml
+++ b/.github/workflows/publish-to-pypi-and-test-pypi.yml
@@ -28,6 +28,7 @@ jobs:
 
   build:
     name: Build distribution 📦
+    needs: [test]  # Make build depend on successful test completion
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- Introduce a new job to run Python tests before publishing to PyPI and TestPyPI.
- Set up Python 3.10 and install dependencies, including pytest.
- Execute tests using the Makefile target to ensure code quality prior to distribution.