### PR TITLE
113 run function in libs must allow running the setup

### DIFF
--- a/cogito/commands/predict.py
+++ b/cogito/commands/predict.py
@@ -3,7 +3,7 @@ import json
 import click
 
 from cogito.core.exceptions import ConfigFileNotFoundError
-from cogito.lib.prediction import run, setup
+from cogito.lib.prediction import run
 
 
 @click.command()
@@ -22,8 +22,7 @@ def predict(ctx: click.Context, payload: str) -> None:
         config_path = ctx.get("config_path")
         payload_data = json.loads(payload)
 
-        setup(config_path)
-        result = run(config_path, payload_data)
+        result = run(config_path, payload_data, run_setup=True)
 
         click.echo(result.model_dump_json(indent=4))
     except ConfigFileNotFoundError:

--- a/cogito/commands/train.py
+++ b/cogito/commands/train.py
@@ -3,7 +3,7 @@ import json
 import click
 
 from cogito.core.exceptions import ConfigFileNotFoundError
-from cogito.lib.training import run, setup
+from cogito.lib.training import run
 
 
 @click.command()
@@ -20,8 +20,7 @@ def train(ctx: click.Context, payload: str) -> None:
         config_path = ctx.get("config_path")
         payload_data = json.loads(payload)
 
-        setup(config_path)
-        result = run(config_path, payload_data)
+        result = run(config_path, payload_data, run_setup=True)
 
         click.echo(result)
     except ConfigFileNotFoundError:

--- a/cogito/lib/prediction.py
+++ b/cogito/lib/prediction.py
@@ -7,21 +7,7 @@ from cogito.core.utils import (
 )
 
 
-def setup(config_path) -> None:
-    """
-    Setup the prediction process
-    """
-
-    config = build_config_file(config_path)
-    predictor = instance_class(config.cogito.get_predictor)
-
-    try:
-        predictor.setup()
-    except Exception as e:
-        raise Exception(f"Error setting up the predictor: {e}")
-
-
-def run(config_path, payload_data) -> dict:
+def run(config_path, payload_data, run_setup=True) -> dict:
     """
     Predict a model using the payload data
     """
@@ -29,6 +15,17 @@ def run(config_path, payload_data) -> dict:
     config = build_config_file(config_path)
     predictor_path = config.cogito.get_predictor
     predictor_instance = instance_class(config.cogito.get_predictor)
+
+    # Run setup if needed
+    try:
+        if (
+            hasattr(predictor_instance, "setup")
+            and callable(getattr(predictor_instance, "setup"))
+            and run_setup
+        ):
+            predictor_instance.setup()
+    except Exception as e:
+        raise Exception(f"Error setting up the predictor: {e}")
 
     # Create input model from payload
     _, input_model_class = create_request_model(

--- a/cogito/lib/training.py
+++ b/cogito/lib/training.py
@@ -2,28 +2,24 @@ from cogito.core.config.file import build_config_file
 from cogito.core.utils import instance_class
 
 
-def setup(config_path) -> None:
-    """
-    Setup the training process
-    """
-
-    config = build_config_file(config_path)
-    trainer = instance_class(config.cogito.get_trainer)
-
-    # Run the setup
-    try:
-        trainer.setup()
-    except Exception as e:
-        raise Exception(f"Error setting up the trainer: {e}")
-
-
-def run(config_path, payload_data):
+def run(config_path, payload_data, run_setup=True):
     """
     Train a model using the payload data
     """
 
     config = build_config_file(config_path)
     trainer = instance_class(config.cogito.get_trainer)
+
+    # Run setup if needed
+    try:
+        if (
+            hasattr(trainer, "setup")
+            and callable(getattr(trainer, "setup"))
+            and run_setup
+        ):
+            trainer.setup()
+    except Exception as e:
+        raise Exception(f"Error setting up the trainer: {e}")
 
     # Call train method with payload data
     try:

--- a/examples/predict.py
+++ b/examples/predict.py
@@ -8,6 +8,7 @@ from cogito import BasePredictor
 class PredictResponse(BaseModel):
     image: str
     text: str
+    my_custom_variable: str
 
 
 class Predictor(BasePredictor):
@@ -22,9 +23,13 @@ class Predictor(BasePredictor):
         ),
     ) -> PredictResponse:
         return PredictResponse(
-            image="https://example.com/image.jpg", text="Hello world"
+            image="https://example.com/image.jpg",
+            text="Hello world",
+            my_custom_variable=self.my_custom_variable,
         )
 
     def setup(self):
         time.sleep(3)
         logging.info("I'm ready")
+
+        self.my_custom_variable = "Hello"

--- a/examples/train.py
+++ b/examples/train.py
@@ -4,7 +4,7 @@ from cogito.core.models import BaseTrainer
 
 class Trainer(BaseTrainer):
     def setup(self):
-        pass
+        self.my_custom_variable = "Hello"
 
     def train(
         self,
@@ -15,7 +15,7 @@ class Trainer(BaseTrainer):
     ):
 
         print(
-            f"Training {model_name} for {epochs} epochs with learning rate {learning_rate} and batch size {batch_size}"
+            f"Training {model_name} for {epochs} epochs with learning rate {learning_rate} and batch size {batch_size} (my_custom_variable: {self.my_custom_variable})"
         )
         time.sleep(5)
 

--- a/tests/commands/test_predict.py
+++ b/tests/commands/test_predict.py
@@ -19,9 +19,8 @@ class TestPredictCommand:
         ctx.get.return_value = "/path/to/cogito.yaml"
         return ctx
 
-    @patch("cogito.commands.predict.setup")
     @patch("cogito.commands.predict.run")
-    def test_predict_success(self, mock_run, mock_setup, cli_runner, mock_context):
+    def test_predict_success(self, mock_run, cli_runner, mock_context):
         # Arrange
         mock_run.return_value = MagicMock(
             model_dump_json=lambda indent: '{"prediction": "test", "probability": 0.95}'
@@ -33,22 +32,22 @@ class TestPredictCommand:
 
         # Assert
         assert result.exit_code == 0
-        mock_setup.assert_called_once_with("/path/to/cogito.yaml")
-        mock_run.assert_called_once()
+        mock_run.assert_called_once_with(
+            "/path/to/cogito.yaml",
+            {"text": "sample text for prediction"},
+            run_setup=True,
+        )
         assert "prediction" in result.output
         assert "test" in result.output
         assert "0.95" in result.output
 
-    @patch("cogito.commands.predict.setup")
     @patch("cogito.commands.predict.run")
-    def test_predict_config_not_found(
-        self, mock_run, mock_setup, cli_runner, mock_context
-    ):
+    def test_predict_config_not_found(self, mock_run, cli_runner, mock_context):
         # Arrange
-        mock_setup.side_effect = ConfigFileNotFoundError(
+        mock_run.side_effect = ConfigFileNotFoundError(
             file_path="/path/to/nonexistent/cogito.yaml"
         )
-        payload = json.dumps({"text": "sample text"})
+        payload = json.dumps({"text": "sample text for prediction"})
 
         # Act
         result = cli_runner.invoke(predict, ["--payload", payload], obj=mock_context)
@@ -57,18 +56,15 @@ class TestPredictCommand:
         assert result.exit_code == 1
         assert "No configuration file found" in result.output
 
-    @patch("cogito.commands.predict.setup")
     @patch("cogito.commands.predict.run")
-    def test_predict_generic_error(
-        self, mock_run, mock_setup, cli_runner, mock_context
-    ):
+    def test_predict_generic_error(self, mock_run, cli_runner, mock_context):
         # Arrange
-        mock_setup.side_effect = Exception("Test error message")
-        payload = json.dumps({"text": "sample text"})
+        mock_run.side_effect = Exception("Test error")
+        payload = json.dumps({"text": "sample text for prediction"})
 
         # Act
         result = cli_runner.invoke(predict, ["--payload", payload], obj=mock_context)
 
         # Assert
         assert result.exit_code == 1
-        assert "Error: Test error message" in result.output
+        assert "Error: Test error" in result.output

--- a/tests/lib/test_prediction.py
+++ b/tests/lib/test_prediction.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
-from cogito.lib.prediction import run, setup
+from cogito.lib.prediction import run
 from cogito.core.exceptions import ConfigFileNotFoundError
 
 
@@ -110,58 +110,3 @@ def test_run_general_exception(
         run("/path/to/cogito.yaml", test_payload)
 
     assert "Test exception" in str(excinfo.value)
-
-
-@patch("cogito.lib.prediction.build_config_file")
-@patch("cogito.lib.prediction.instance_class")
-def test_setup_successful(
-    mock_instance_class, mock_build_config_file, mock_config_file
-):
-    # Setup mocks
-    mock_build_config_file.return_value = mock_config_file
-
-    predictor_instance = MockPredictor()
-    mock_instance_class.return_value = predictor_instance
-
-    # Call setup function
-    config_path = "/path/to/cogito.yaml"
-    setup(config_path)
-
-    # Assertions
-    mock_build_config_file.assert_called_once_with(config_path)
-    mock_instance_class.assert_called_once_with(mock_config_file.cogito.get_predictor)
-    predictor_instance.setup.assert_called_once()
-
-
-@patch("cogito.lib.prediction.build_config_file")
-def test_setup_config_not_found(mock_build_config_file):
-    # Setup mock to raise the exception
-    mock_build_config_file.side_effect = ConfigFileNotFoundError(
-        file_path="/path/to/nonexistent/cogito.yaml"
-    )
-
-    # Call the function and check for raised exception
-    with pytest.raises(ConfigFileNotFoundError):
-        setup("/path/to/nonexistent/cogito.yaml")
-
-
-@patch("cogito.lib.prediction.build_config_file")
-@patch("cogito.lib.prediction.instance_class")
-def test_setup_general_exception(
-    mock_instance_class, mock_build_config_file, mock_config_file
-):
-    # Setup mocks
-    mock_build_config_file.return_value = mock_config_file
-
-    # Create and setup the exception
-    mock_predictor = MockPredictor()
-    mock_instance_class.return_value = mock_predictor
-
-    error_message = "Error in setup"
-    mock_predictor.setup.side_effect = Exception(error_message)
-
-    # Call the function and check for raised exception
-    with pytest.raises(Exception) as excinfo:
-        setup("/path/to/cogito.yaml")
-
-    assert error_message in str(excinfo.value)

--- a/tests/lib/test_training.py
+++ b/tests/lib/test_training.py
@@ -6,7 +6,7 @@ from unittest.mock import patch, MagicMock
 # Add the parent directory to sys.path to allow importing cogito modules
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-from cogito.lib.training import run, setup
+from cogito.lib.training import run
 from cogito.core.exceptions import ConfigFileNotFoundError
 
 
@@ -111,57 +111,6 @@ class TestTraining(unittest.TestCase):
         # Verify sys.path was modified correctly
         # Instead of patching sys.path.insert, we patch sys.path and check that insert was called
         mock_sys_path.insert.assert_not_called()  # Should not be called in our implementation
-
-    @patch("cogito.lib.training.build_config_file")
-    @patch("cogito.lib.training.instance_class")
-    def test_setup_success(self, mock_instance_class, mock_build_config_file):
-        # Setup
-        mock_config = MagicMock()
-        mock_config.cogito.get_trainer = "path.to.MockTrainer"
-        mock_build_config_file.return_value = mock_config
-
-        mock_trainer = MockTrainer()
-        mock_instance_class.return_value = mock_trainer
-
-        # Execute
-        setup("/path/to/cogito.yaml")
-
-        # Verify
-        mock_build_config_file.assert_called_once_with("/path/to/cogito.yaml")
-        mock_instance_class.assert_called_once_with("path.to.MockTrainer")
-        mock_trainer.setup.assert_called_once()
-
-    @patch("cogito.lib.training.build_config_file")
-    def test_setup_config_not_found(self, mock_build_config_file):
-        # Setup - simulate config file not found
-        mock_build_config_file.side_effect = ConfigFileNotFoundError(
-            file_path="/path/to/nonexistent/cogito.yaml"
-        )
-
-        # Execute and verify exception is raised
-        with self.assertRaises(ConfigFileNotFoundError):
-            setup("/path/to/nonexistent/cogito.yaml")
-
-    @patch("cogito.lib.training.build_config_file")
-    @patch("cogito.lib.training.instance_class")
-    def test_setup_general_exception(self, mock_instance_class, mock_build_config_file):
-        # Setup
-        mock_config = MagicMock()
-        mock_config.cogito.get_trainer = "path.to.MockTrainer"
-        mock_build_config_file.return_value = mock_config
-
-        mock_trainer = MockTrainer()
-        mock_instance_class.return_value = mock_trainer
-
-        # Setup exception
-        error_message = "Setup error"
-        mock_trainer.setup.side_effect = Exception(error_message)
-
-        # Execute and verify exception is raised
-        with self.assertRaises(Exception) as context:
-            setup("/path/to/cogito.yaml")
-
-        self.assertIn(error_message, str(context.exception))
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "cogito"
-version = "0.3.0a2"
+version = "0.3.0a3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This pull request includes multiple changes to the `cogito` package, primarily focusing on refactoring the prediction and training commands to streamline the setup process and updating the corresponding tests. The most important changes include removing the `setup` function, modifying the `run` function to handle setup internally, and updating tests to reflect these changes.

### Refactoring Prediction and Training Commands:

* [`cogito/commands/predict.py`](diffhunk://#diff-b3e11ee41072385edbcb651f416ac876ca12256bef150bd296d4cfce9b5cbc36L6-R6): Removed the `setup` import and modified the `run` function call to include a `run_setup` parameter. [[1]](diffhunk://#diff-b3e11ee41072385edbcb651f416ac876ca12256bef150bd296d4cfce9b5cbc36L6-R6) [[2]](diffhunk://#diff-b3e11ee41072385edbcb651f416ac876ca12256bef150bd296d4cfce9b5cbc36L25-R25)
* [`cogito/commands/train.py`](diffhunk://#diff-c1ea4583dc51e211a0716a3da28843764c1a593697c301a516a297a1bd09e3f4L6-R6): Removed the `setup` import and modified the `run` function call to include a `run_setup` parameter. [[1]](diffhunk://#diff-c1ea4583dc51e211a0716a3da28843764c1a593697c301a516a297a1bd09e3f4L6-R6) [[2]](diffhunk://#diff-c1ea4583dc51e211a0716a3da28843764c1a593697c301a516a297a1bd09e3f4L23-R23)

### Updating Prediction and Training Logic:

* [`cogito/lib/prediction.py`](diffhunk://#diff-40c0a94d99afc519bf9ccf4ed4291897aea4ab0730005c21b13fba97e83fc35fL10-L32): Removed the `setup` function and integrated its logic into the `run` function with a `run_setup` parameter.
* [`cogito/lib/training.py`](diffhunk://#diff-07d54bcbf62f92727ce620883da98adea05d1175ef76bb83d3e679696acd4d81L5-L27): Removed the `setup` function and integrated its logic into the `run` function with a `run_setup` parameter.

### Enhancing Examples:

* [`examples/predict.py`](diffhunk://#diff-0aae350a4ae0b1b8dc4af9607c5a85f5941091eae5f3939363a70768089ec64fR11): Added a new variable `my_custom_variable` to the `PredictResponse` class and updated the `predict` method to include this variable. [[1]](diffhunk://#diff-0aae350a4ae0b1b8dc4af9607c5a85f5941091eae5f3939363a70768089ec64fR11) [[2]](diffhunk://#diff-0aae350a4ae0b1b8dc4af9607c5a85f5941091eae5f3939363a70768089ec64fL25-R35)
* [`examples/train.py`](diffhunk://#diff-96ed6001dec438af8cae0e5e33c7f99744cd26f34a3ec45be5921cae2076b087L7-R7): Updated the `setup` and `train` methods in the `Trainer` class to include a new variable `my_custom_variable`. [[1]](diffhunk://#diff-96ed6001dec438af8cae0e5e33c7f99744cd26f34a3ec45be5921cae2076b087L7-R7) [[2]](diffhunk://#diff-96ed6001dec438af8cae0e5e33c7f99744cd26f34a3ec45be5921cae2076b087L18-R18)

### Updating Tests:

* [`tests/commands/test_predict.py`](diffhunk://#diff-629d62a2efd053d4c22594a90d074d53d1ef857ee6ed1a3f3b20179cdf953886L22-R23): Removed `setup` related patches and assertions, and updated `run` function calls to include `run_setup` parameter. [[1]](diffhunk://#diff-629d62a2efd053d4c22594a90d074d53d1ef857ee6ed1a3f3b20179cdf953886L22-R23) [[2]](diffhunk://#diff-629d62a2efd053d4c22594a90d074d53d1ef857ee6ed1a3f3b20179cdf953886L36-R50) [[3]](diffhunk://#diff-629d62a2efd053d4c22594a90d074d53d1ef857ee6ed1a3f3b20179cdf953886L60-R70)
* [`tests/commands/test_train.py`](diffhunk://#diff-41bf49f9b623583b93aca285dfadbdd3f7d5896a6f10e3fc2b844312dba37ed8R15-R72): Removed `setup` related patches and assertions, and updated `run` function calls to include `run_setup` parameter.
* [`tests/lib/test_prediction.py`](diffhunk://#diff-73d993be4bf09329e1e4be75cff4780fb5879471ac4adfafdb7e1c0f3a24881fL4-R4): Removed `setup` related tests. [[1]](diffhunk://#diff-73d993be4bf09329e1e4be75cff4780fb5879471ac4adfafdb7e1c0f3a24881fL4-R4) [[2]](diffhunk://#diff-73d993be4bf09329e1e4be75cff4780fb5879471ac4adfafdb7e1c0f3a24881fL113-L167)
* [`tests/lib/test_training.py`](diffhunk://#diff-88741612a050eac9fe6c98057629e9e006d75881c37d72ebd1985eb1d640a8cfL9-R9): Removed `setup` related tests. [[1]](diffhunk://#diff-88741612a050eac9fe6c98057629e9e006d75881c37d72ebd1985eb1d640a8cfL9-R9) [[2]](diffhunk://#diff-88741612a050eac9fe6c98057629e9e006d75881c37d72ebd1985eb1d640a8cfL115-L165)