### PR TITLE
Improve cogito library sdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,6 @@ code-style-check: ## Checks the code style.
 code-style-dirty: ## Fixes the code style but does not commit the changes
 	@$(ACTIVATE) && black .
 
-code-style: code-style-dirty ## Check the code style and commit the changes
-	@git commit -am "style: fix code style"
-
 pre-commit-install: ## Install pre-commit hooks
 	@pre-commit install --hook-type pre-commit --hook-type pre-push
 

--- a/cogito/commands/predict.py
+++ b/cogito/commands/predict.py
@@ -2,8 +2,8 @@ import json
 
 import click
 
-from cogito.core.exceptions import ConfigFileNotFoundError
-from cogito.lib.prediction import run
+from cogito.core.exceptions import ConfigFileNotFoundError, NoSetupMethodError
+from cogito.lib.prediction import Predict
 
 
 @click.command()
@@ -18,15 +18,31 @@ def predict(ctx: click.Context, payload: str) -> None:
     Example: python -m cogito.cli predict --payload '{"key": "value"}'
     """
 
+    # Load config and initialize predictor
     try:
         config_path = ctx.get("config_path")
         payload_data = json.loads(payload)
+        predictor = Predict(config_path)
+    except Exception as e:
+        click.echo(f"Error initializing the predictor: {e}", err=True, color=True)
+        exit(1)
 
-        result = run(config_path, payload_data, run_setup=True)
+    # Setup predictor
+    try:
+        predictor.setup()
+    except NoSetupMethodError as e:
+        click.echo(f"Warning: {e}", err=True, color=True)
+    except Exception as e:
+        click.echo(f"Error setting up the predictor: {e}", err=True, color=True)
+        exit(1)
+
+    # Run predictor
+    try:
+        result = predictor.run(payload_data)
 
         click.echo(result.model_dump_json(indent=4))
-    except ConfigFileNotFoundError:
-        click.echo("No configuration file found. Please initialize the project first.")
+    except ConfigFileNotFoundError as e:
+        click.echo(f"Config file not found: {e}", err=True, color=True)
         exit(1)
     except Exception as e:
         # print stack trace

--- a/cogito/core/exceptions.py
+++ b/cogito/core/exceptions.py
@@ -27,3 +27,8 @@ class BadRequestError(Exception):
     def __init__(self, message: str):
         super().__init__(message)
         self.message = message
+
+
+class NoSetupMethodError(Exception):
+    def __init__(self, class_name: str):
+        super().__init__(f"No setup method found for {class_name}")

--- a/cogito/lib/training.py
+++ b/cogito/lib/training.py
@@ -1,30 +1,39 @@
 from cogito.core.config.file import build_config_file
 from cogito.core.utils import instance_class
+from cogito.core.exceptions import NoSetupMethodError
 
 
-def run(config_path, payload_data, run_setup=True):
-    """
-    Train a model using the payload data
-    """
+# SDK Trainer class
+class Trainer:
 
-    config = build_config_file(config_path)
-    trainer = instance_class(config.cogito.get_trainer)
+    # Initialize trainer
+    def __init__(self, config_path):
+        # Build config
+        config = build_config_file(config_path)
 
-    # Run setup if needed
-    try:
-        if (
-            hasattr(trainer, "setup")
-            and callable(getattr(trainer, "setup"))
-            and run_setup
-        ):
-            trainer.setup()
-    except Exception as e:
-        raise Exception(f"Error setting up the trainer: {e}")
+        # Get trainer path and instance
+        self.config_path = config_path
+        self.trainer = instance_class(config.cogito.get_trainer)
 
-    # Call train method with payload data
-    try:
-        result = trainer.train(**payload_data)
-    except Exception as e:
-        raise Exception(f"Error training the model: {e}")
+    # Setup trainer calling setup method in the user's code
+    def setup(self):
+        # Run setup if needed
+        try:
+            if hasattr(self.trainer, "setup") and callable(
+                getattr(self.trainer, "setup")
+            ):
+                self.trainer.setup()
+            else:
+                raise NoSetupMethodError(self.trainer.__class__.__name__)
+        except Exception as e:
+            raise Exception(f"Error setting up the trainer: {e}")
 
-    return result
+    # Run training calling train method in the user's code
+    def run(self, payload_data, run_setup=True):
+        # Call train method with payload data
+        try:
+            result = self.trainer.train(**payload_data)
+        except Exception as e:
+            raise Exception(f"Error training the model: {e}")
+
+        return result

--- a/tests/lib/test_prediction.py
+++ b/tests/lib/test_prediction.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
-from cogito.lib.prediction import run
+from cogito.lib.prediction import Predict
 from cogito.core.exceptions import ConfigFileNotFoundError
 
 
@@ -61,7 +61,8 @@ def test_run_successful(
 
     # Call the function
     config_path = "/path/to/cogito.yaml"
-    result = run(config_path, test_payload)
+    predictor = Predict(config_path)
+    result = predictor.run(test_payload)
 
     # Assertions
     mock_build_config_file.assert_called_once_with(config_path)
@@ -84,7 +85,7 @@ def test_run_config_not_found(mock_build_config_file, test_payload):
 
     # Call the function and check for raised exception
     with pytest.raises(ConfigFileNotFoundError):
-        run("/path/to/nonexistent/cogito.yaml", test_payload)
+        predictor = Predict("/path/to/nonexistent/cogito.yaml")
 
 
 @patch("cogito.lib.prediction.build_config_file")
@@ -107,6 +108,6 @@ def test_run_general_exception(
 
     # Call the function and check for raised exception
     with pytest.raises(TestException) as excinfo:
-        run("/path/to/cogito.yaml", test_payload)
+        predictor = Predict("/path/to/cogito.yaml")
 
     assert "Test exception" in str(excinfo.value)

--- a/tests/lib/test_training.py
+++ b/tests/lib/test_training.py
@@ -6,7 +6,7 @@ from unittest.mock import patch, MagicMock
 # Add the parent directory to sys.path to allow importing cogito modules
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-from cogito.lib.training import run
+from cogito.lib.training import Trainer
 from cogito.core.exceptions import ConfigFileNotFoundError
 
 
@@ -41,7 +41,8 @@ class TestTraining(unittest.TestCase):
         payload_data = {"data_path": "/path/to/data", "epochs": 10}
 
         # Execute
-        result = run(config_path, payload_data)
+        trainer = Trainer(config_path)
+        result = trainer.run(payload_data)
 
         # Verify
         # Check that the config was loaded with the correct path
@@ -67,7 +68,7 @@ class TestTraining(unittest.TestCase):
 
         # Execute and verify exception is raised
         with self.assertRaises(ConfigFileNotFoundError):
-            run("/path/to/nonexistent/cogito.yaml", {})
+            trainer = Trainer("/path/to/nonexistent/cogito.yaml")
 
     @patch("cogito.lib.training.build_config_file")
     @patch("cogito.lib.training.instance_class")
@@ -83,7 +84,7 @@ class TestTraining(unittest.TestCase):
 
         # Execute and verify exception is raised
         with self.assertRaises(Exception) as context:
-            run("/path/to/cogito.yaml", {})
+            trainer = Trainer("/path/to/cogito.yaml")
 
         self.assertIn(error_message, str(context.exception))
 
@@ -106,7 +107,8 @@ class TestTraining(unittest.TestCase):
         payload_data = {"data_path": "/path/to/data"}
 
         # Execute
-        run(config_path, payload_data)
+        trainer = Trainer(config_path)
+        trainer.run(payload_data)
 
         # Verify sys.path was modified correctly
         # Instead of patching sys.path.insert, we patch sys.path and check that insert was called

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "cogito"
-version = "0.3.0a3"
+version = "0.3.0a4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This pull request introduces significant changes to the `cogito` package, focusing on refactoring the prediction and training functionalities to use new `Predict` and `Trainer` classes, respectively. Additionally, it includes updates to the exception handling mechanisms and corresponding unit tests.

Refactoring and new classes:

* [`cogito/commands/predict.py`](diffhunk://#diff-b3e11ee41072385edbcb651f416ac876ca12256bef150bd296d4cfce9b5cbc36L5-R6): Replaced the `run` function with the `Predict` class for handling prediction logic, including initialization, setup, and execution. [[1]](diffhunk://#diff-b3e11ee41072385edbcb651f416ac876ca12256bef150bd296d4cfce9b5cbc36L5-R6) [[2]](diffhunk://#diff-b3e11ee41072385edbcb651f416ac876ca12256bef150bd296d4cfce9b5cbc36R21-R45)
* [`cogito/commands/train.py`](diffhunk://#diff-c1ea4583dc51e211a0716a3da28843764c1a593697c301a516a297a1bd09e3f4L5-R6): Replaced the `run` function with the `Trainer` class for handling training logic, including initialization, setup, and execution. [[1]](diffhunk://#diff-c1ea4583dc51e211a0716a3da28843764c1a593697c301a516a297a1bd09e3f4L5-R6) [[2]](diffhunk://#diff-c1ea4583dc51e211a0716a3da28843764c1a593697c301a516a297a1bd09e3f4R19-R49)

Exception handling improvements:

* [`cogito/core/exceptions.py`](diffhunk://#diff-66d430bc591692911ed05db565ec2156d134e4d95c5dbd1a64a0506f4b082888R30-R34): Added a new `NoSetupMethodError` exception class to handle cases where the setup method is missing in user-defined classes.
* [`cogito/lib/prediction.py`](diffhunk://#diff-40c0a94d99afc519bf9ccf4ed4291897aea4ab0730005c21b13fba97e83fc35fR8-R51): Integrated the `NoSetupMethodError` into the `Predict` class to handle setup-related errors.
* [`cogito/lib/training.py`](diffhunk://#diff-07d54bcbf62f92727ce620883da98adea05d1175ef76bb83d3e679696acd4d81R3-R35): Integrated the `NoSetupMethodError` into the `Trainer` class to handle setup-related errors.

Unit test updates:

* [`tests/commands/test_predict.py`](diffhunk://#diff-629d62a2efd053d4c22594a90d074d53d1ef857ee6ed1a3f3b20179cdf953886L22-R55): Updated tests to mock the `Predict` class instead of the `run` function, ensuring proper initialization, setup, and execution are tested. [[1]](diffhunk://#diff-629d62a2efd053d4c22594a90d074d53d1ef857ee6ed1a3f3b20179cdf953886L22-R55) [[2]](diffhunk://#diff-629d62a2efd053d4c22594a90d074d53d1ef857ee6ed1a3f3b20179cdf953886L57-R78)
* [`tests/commands/test_train.py`](diffhunk://#diff-41bf49f9b623583b93aca285dfadbdd3f7d5896a6f10e3fc2b844312dba37ed8L27-R54): Updated tests to mock the `Trainer` class instead of the `run` function, ensuring proper initialization, setup, and execution are tested. [[1]](diffhunk://#diff-41bf49f9b623583b93aca285dfadbdd3f7d5896a6f10e3fc2b844312dba37ed8L27-R54) [[2]](diffhunk://#diff-41bf49f9b623583b93aca285dfadbdd3f7d5896a6f10e3fc2b844312dba37ed8L58-R70)
* [`tests/lib/test_prediction.py`](diffhunk://#diff-73d993be4bf09329e1e4be75cff4780fb5879471ac4adfafdb7e1c0f3a24881fL4-R4): Modified tests to use the `Predict` class for prediction-related tests. [[1]](diffhunk://#diff-73d993be4bf09329e1e4be75cff4780fb5879471ac4adfafdb7e1c0f3a24881fL4-R4) [[2]](diffhunk://#diff-73d993be4bf09329e1e4be75cff4780fb5879471ac4adfafdb7e1c0f3a24881fL64-R65) [[3]](diffhunk://#diff-73d993be4bf09329e1e4be75cff4780fb5879471ac4adfafdb7e1c0f3a24881fL87-R88) [[4]](diffhunk://#diff-73d993be4bf09329e1e4be75cff4780fb5879471ac4adfafdb7e1c0f3a24881fL110-R111)
* [`tests/lib/test_training.py`](diffhunk://#diff-88741612a050eac9fe6c98057629e9e006d75881c37d72ebd1985eb1d640a8cfL9-R9): Modified tests to use the `Trainer` class for training-related tests. [[1]](diffhunk://#diff-88741612a050eac9fe6c98057629e9e006d75881c37d72ebd1985eb1d640a8cfL9-R9) [[2]](diffhunk://#diff-88741612a050eac9fe6c98057629e9e006d75881c37d72ebd1985eb1d640a8cfL44-R45) [[3]](diffhunk://#diff-88741612a050eac9fe6c98057629e9e006d75881c37d72ebd1985eb1d640a8cfL70-R71) [[4]](diffhunk://#diff-88741612a050eac9fe6c98057629e9e006d75881c37d72ebd1985eb1d640a8cfL86-R87) [[5]](diffhunk://#diff-88741612a050eac9fe6c98057629e9e006d75881c37d72ebd1985eb1d640a8cfL109-R111)

Other changes:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L58-L60): Removed the `code-style` target that committed code style fixes automatically.